### PR TITLE
feature/03092021_automatic_slot_creation_trigger

### DIFF
--- a/app/controllers/appointment_types_controller.rb
+++ b/app/controllers/appointment_types_controller.rb
@@ -17,6 +17,7 @@ class AppointmentTypesController < ApplicationController
     authorize @appointment_type
 
     if @appointment_type.update(place_params)
+      SlotCreationJob.perform_later oneshot: true
       redirect_to appointment_types_path
     else
       render :edit

--- a/app/jobs/slot_creation_job.rb
+++ b/app/jobs/slot_creation_job.rb
@@ -1,6 +1,6 @@
 class SlotCreationJob < ApplicationJob
-  def perform
+  def perform(oneshot: false)
     SlotFactory.perform
-    SlotCreationJob.set(wait: 1.week).perform_later
+    SlotCreationJob.set(wait: 1.week).perform_later unless oneshot
   end
 end

--- a/spec/features/appointment_types_spec.rb
+++ b/spec/features/appointment_types_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature 'AppointmentType', type: :feature do
 
       @appointment_type.reload
       expect(@appointment_type.name).to eq('2e contact')
+      expect(SlotCreationJob).to have_been_enqueued.once.with(oneshot: true)
     end
 
     it 'allows to update notification types' do
@@ -69,6 +70,7 @@ RSpec.feature 'AppointmentType', type: :feature do
 
       notif_type3.reload
       expect(notif_type3.template).to eq('Bwah')
+      expect(SlotCreationJob).to have_been_enqueued.once.with(oneshot: true)
     end
 
     it 'allows to add slot types', js: true do
@@ -84,6 +86,7 @@ RSpec.feature 'AppointmentType', type: :feature do
       end
 
       expect { click_button('Enregistrer') }.to change { SlotType.count }.by(1)
+      expect(SlotCreationJob).to have_been_enqueued.once.with(oneshot: true)
     end
   end
 end

--- a/spec/jobs/slot_creation_job_spec.rb
+++ b/spec/jobs/slot_creation_job_spec.rb
@@ -12,19 +12,31 @@ RSpec.describe SlotCreationJob, type: :job do
 
   describe '#perform' do
     let(:frozen_time) { Time.zone.parse '2021-05-03' }
-    let(:tested_method) { SlotCreationJob.new.perform }
-
     before do
       allow(Time).to receive(:now).and_return frozen_time
       allow(SlotFactory).to receive(:perform)
-      tested_method
     end
 
-    it 'instantiates Slot factory' do
-      expect(SlotFactory).to have_received(:perform).once
+    context 'with auto-relaunch for the job' do
+      before { SlotCreationJob.new.perform }
+
+      it 'instantiates Slot factory' do
+        expect(SlotFactory).to have_received(:perform).once
+      end
+      it 'queues itself for next week' do
+        expect(SlotCreationJob).to have_been_enqueued.once.at(1.week.since)
+      end
     end
-    it 'queues itself for next week' do
-      expect(SlotCreationJob).to have_been_enqueued.once.at(1.week.since)
+
+    context 'with one shot option' do
+      before { SlotCreationJob.new.perform oneshot: true }
+
+      it 'instantiates Slot factory' do
+        expect(SlotFactory).to have_received(:perform).once
+      end
+      it 'does not queues itself for next week' do
+        expect(SlotCreationJob).not_to have_been_enqueued
+      end
     end
   end
 end

--- a/spec/jobs/slot_creation_job_spec.rb
+++ b/spec/jobs/slot_creation_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SlotCreationJob, type: :job do
     context 'with auto-relaunch for the job' do
       before { SlotCreationJob.new.perform }
 
-      it 'instantiates Slot factory' do
+      it 'performs Slot factory' do
         expect(SlotFactory).to have_received(:perform).once
       end
       it 'queues itself for next week' do
@@ -31,7 +31,7 @@ RSpec.describe SlotCreationJob, type: :job do
     context 'with one shot option' do
       before { SlotCreationJob.new.perform oneshot: true }
 
-      it 'instantiates Slot factory' do
+      it 'performs Slot factory' do
         expect(SlotFactory).to have_received(:perform).once
       end
       it 'does not queues itself for next week' do


### PR DESCRIPTION
Proposal :
On appointment type update, the slot creation job will be triggered, so slot are available asap

Could also be a after_save callback on SlotType