### PR TITLE
Restrict access to data by department

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,3 +55,8 @@ Metrics/MethodLength:
   Exclude:
     - app/services/notification_factory.rb
     - app/helpers/users_helper.rb
+
+Metrics/AbcSize:
+  Exclude:
+    - app/policies/convict_policy.rb
+    - app/policies/place_policy.rb

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -2,7 +2,7 @@ class PlacesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @places = Place.all.page params[:page]
+    @places = policy_scope(Place).page params[:page]
     authorize @places
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @users = User.all.order('last_name asc').page params[:page]
+    @users = policy_scope(User).order('last_name asc').page params[:page]
     authorize @users
   end
 

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -36,6 +36,11 @@ class Convict < ApplicationRecord
            ).distinct
   }
 
+  scope :in_department, lambda { |department|
+    joins(:areas_convicts_mappings)
+      .where(areas_convicts_mappings: { area_type: 'Department', area_id: department.id })
+  }
+
   def name
     "#{last_name.upcase} #{first_name.capitalize}"
   end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -13,4 +13,6 @@ class Place < ApplicationRecord
   accepts_nested_attributes_for :place_appointment_types
 
   scope :in_organization, ->(organization) { where(organization: organization) }
+
+  scope :bex_selection, ->(department) { joins(:organization).where(organization: {area: department})}
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -13,6 +13,5 @@ class Place < ApplicationRecord
   accepts_nested_attributes_for :place_appointment_types
 
   scope :in_organization, ->(organization) { where(organization: organization) }
-
-  scope :bex_selection, ->(department) { joins(:organization).where(organization: {area: department})}
+  scope :in_department, ->(department) { joins(:organization).where(organization: {area: department})}
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -13,5 +13,6 @@ class Place < ApplicationRecord
   accepts_nested_attributes_for :place_appointment_types
 
   scope :in_organization, ->(organization) { where(organization: organization) }
-  scope :in_department, ->(department) { joins(:organization).where(organization: {area: department})}
+
+  scope :in_department, ->(department) { joins(:organization).where(organization: { area: department }) }
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -14,5 +14,8 @@ class Place < ApplicationRecord
 
   scope :in_organization, ->(organization) { where(organization: organization) }
 
-  scope :in_department, ->(department) { joins(:organization).where(organization: { area: department }) }
+  scope :in_department, lambda { |department|
+    joins(organization: :areas_organizations_mappings)
+      .where(areas_organizations_mappings: { area_type: 'Department', area_id: department.id })
+  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,11 @@ class User < ApplicationRecord
 
   validates :first_name, :last_name, :role, presence: true
 
+  scope :in_department, lambda { |department|
+    joins(organization: :areas_organizations_mappings)
+      .where(areas_organizations_mappings: { area_type: 'Department', area_id: department.id })
+  }
+
   def name
     "#{last_name.upcase} #{first_name.capitalize}"
   end

--- a/app/policies/convict_policy.rb
+++ b/app/policies/convict_policy.rb
@@ -5,7 +5,7 @@ class ConvictPolicy < ApplicationPolicy
     def resolve
       if user.admin?
         scope.all
-      elsif user.bex? || user.sap?
+      elsif user.local_admin? || user.bex? || user.sap?
         scope.in_department(user.organization.departments.first)
       else
         scope.in_organization(organization)

--- a/app/policies/convict_policy.rb
+++ b/app/policies/convict_policy.rb
@@ -8,7 +8,7 @@ class ConvictPolicy < ApplicationPolicy
       elsif user.local_admin? || user.bex? || user.sap?
         scope.in_department(user.organization.departments.first)
       else
-        scope.in_organization(organization)
+        scope.under_hand_of(organization)
       end
     end
   end

--- a/app/policies/convict_policy.rb
+++ b/app/policies/convict_policy.rb
@@ -3,10 +3,12 @@ class ConvictPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user.admin? || user.bex? || user.sap?
+      if user.admin?
         scope.all
+      elsif user.bex? || user.sap?
+        scope.in_department(user.organization.departments.first)
       else
-        scope.under_hand_of(organization)
+        scope.in_organization(organization)
       end
     end
   end

--- a/app/policies/place_policy.rb
+++ b/app/policies/place_policy.rb
@@ -4,7 +4,7 @@ class PlacePolicy < ApplicationPolicy
       if user.admin?
         scope.all
       elsif user.bex? || user.sap?
-        scope.bex_selection(user.area)
+        scope.in_department(user.organization.departments.first)
       else
         scope.in_organization(organization)
       end

--- a/app/policies/place_policy.rb
+++ b/app/policies/place_policy.rb
@@ -3,7 +3,7 @@ class PlacePolicy < ApplicationPolicy
     def resolve
       if user.admin?
         scope.all
-      elsif user.bex? || user.sap?
+      elsif user.local_admin? || user.bex? || user.sap?
         scope.in_department(user.organization.departments.first)
       else
         scope.in_organization(organization)

--- a/app/policies/place_policy.rb
+++ b/app/policies/place_policy.rb
@@ -1,8 +1,10 @@
 class PlacePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      if user.admin? || user.bex? || user.sap?
+      if user.admin?
         scope.all
+      elsif user.bex? || user.sap?
+        scope.bex_selection(user.area)
       else
         scope.in_organization(organization)
       end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,14 @@
 class UserPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if user.admin?
+        scope.all
+      elsif user.local_admin?
+        scope.in_department(user.organization.departments.first)
+      end
+    end
+  end
+
   def index?
     user.admin? || user.local_admin?
   end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -79,7 +79,12 @@ RSpec.feature 'Users', type: :feature do
     end
 
     it 'forbid bex users to access some interfaces' do
-      bex_user = create(:user, role: :bex)
+      department = create :department, number: '01', name: 'Ain'
+
+      organization = create :organization
+      create :areas_organizations_mapping, organization: organization, area: department
+
+      bex_user = create(:user, role: :bex, organization: organization)
       logout_current_user
       login_user(bex_user)
 

--- a/spec/models/convict_spec.rb
+++ b/spec/models/convict_spec.rb
@@ -159,9 +159,9 @@ RSpec.describe Convict, type: :model do
     end
   end
 
-  describe '.in_department', :focus do
+  describe '.in_department' do
     it 'returns convicts scoped by department' do
-      department1 = Department.find_or_create_by name: 'Creuse'
+      department1 = create :department, number: '01', name: 'Ain'
 
       convict1 = create :convict
       create :areas_convicts_mapping, convict: convict1, area: department1
@@ -169,7 +169,7 @@ RSpec.describe Convict, type: :model do
       convict2 = create :convict
       create :areas_convicts_mapping, convict: convict2, area: department1
 
-      department2 = Department.find_or_create_by name: 'Ain'
+      department2 = create :department, number: '02', name: 'Aisne'
 
       convict3 = create :convict
       create :areas_convicts_mapping, convict: convict3, area: department2

--- a/spec/models/convict_spec.rb
+++ b/spec/models/convict_spec.rb
@@ -158,4 +158,23 @@ RSpec.describe Convict, type: :model do
       end
     end
   end
+
+  describe '.in_department', :focus do
+    it 'returns convicts scoped by department' do
+      department1 = Department.find_or_create_by name: 'Creuse'
+
+      convict1 = create :convict
+      create :areas_convicts_mapping, convict: convict1, area: department1
+
+      convict2 = create :convict
+      create :areas_convicts_mapping, convict: convict2, area: department1
+
+      department2 = Department.find_or_create_by name: 'Ain'
+
+      convict3 = create :convict
+      create :areas_convicts_mapping, convict: convict3, area: department2
+
+      expect(Convict.in_department(department1)).to eq [convict1, convict2]
+    end
+  end
 end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe Place, type: :model do
     end
   end
 
-  describe '.in_department', :focus do
+  describe '.in_department' do
     it 'returns places scoped by department' do
-      department1 = Department.find_or_create_by name: 'Creuse'
+      department1 = create :department, number: '01', name: 'Ain'
 
       organization1 = create :organization
       create :areas_organizations_mapping, organization: organization1, area: department1
@@ -45,7 +45,7 @@ RSpec.describe Place, type: :model do
       create :areas_organizations_mapping, organization: organization2, area: department1
       place2 = create :place, organization: organization2
 
-      department2 = Department.find_or_create_by name: 'Ain'
+      department2 = create :department, number: '02', name: 'Aisne'
 
       organization3 = create :organization
       create :areas_organizations_mapping, organization: organization3, area: department2

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -32,4 +32,26 @@ RSpec.describe Place, type: :model do
       expect(Place.in_organization(@organization)).to eq [@place_in]
     end
   end
+
+  describe '.bex_selection', :focus do
+    it 'returns places available for bex user' do
+      department1 = Department.find_or_create_by name: 'Creuse'
+
+      organization1 = create :organization
+      create :areas_organizations_mapping, organization: organization1, area: department1
+      place1 = create :place, organization: organization1
+
+      organization2 = create :organization
+      create :areas_organizations_mapping, organization: organization2, area: department1
+      place2 = create :place, organization: organization2
+
+      department2 = Department.find_or_create_by name: 'Ain'
+
+      organization3 = create :organization
+      create :areas_organizations_mapping, organization: organization3, area: department2
+      place3 = create :place, organization: organization3
+
+      expect(Place.bex_selection(department1)).to eq [place1, place2]
+    end
+  end
 end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Place, type: :model do
   end
 
   describe '.in_department', :focus do
-    it 'returns places available for bex user' do
+    it 'returns places scoped by department' do
       department1 = Department.find_or_create_by name: 'Creuse'
 
       organization1 = create :organization

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Place, type: :model do
     end
   end
 
-  describe '.bex_selection', :focus do
+  describe '.in_department', :focus do
     it 'returns places available for bex user' do
       department1 = Department.find_or_create_by name: 'Creuse'
 
@@ -51,7 +51,7 @@ RSpec.describe Place, type: :model do
       create :areas_organizations_mapping, organization: organization3, area: department2
       place3 = create :place, organization: organization3
 
-      expect(Place.bex_selection(department1)).to eq [place1, place2]
+      expect(Place.in_department(department1)).to eq [place1, place2]
     end
   end
 end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Place, type: :model do
 
       organization3 = create :organization
       create :areas_organizations_mapping, organization: organization3, area: department2
-      place3 = create :place, organization: organization3
+      create :place, organization: organization3
 
       expect(Place.in_department(department1)).to eq [place1, place2]
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,4 +31,26 @@ RSpec.describe User, type: :model do
       }
     )
   }
+
+  describe '.in_department' do
+    it 'returns places scoped by department' do
+      department1 = create :department, number: '01', name: 'Ain'
+
+      organization1 = create :organization
+      create :areas_organizations_mapping, organization: organization1, area: department1
+      user1 = create :user, organization: organization1
+
+      organization2 = create :organization
+      create :areas_organizations_mapping, organization: organization2, area: department1
+      user2 = create :user, organization: organization2
+
+      department2 = create :department, number: '02', name: 'Aisne'
+
+      organization3 = create :organization
+      create :areas_organizations_mapping, organization: organization3, area: department2
+      create :user, organization: organization3
+
+      expect(User.in_department(department1)).to eq [user1, user2]
+    end
+  end
 end


### PR DESCRIPTION
Crée un scope `.in_department` pour les convict, les lieux et les users pour pouvoir afficher seulement les bonnes données aux utilisateurs du bex et aux admins locaux.

Traite les tickets suivants :

https://trello.com/c/i7pBsSV3/500-habilitations-choix-du-d%C3%A9partement-ou-juridiction-de-la-ppsmj
https://trello.com/c/DEiI55lR/499-habilitations-en-tant-quadministrateur-de-ressort-je-veux-ne-voir-safficher-que-les-informations-de-mon-propre-ressort-et-ne-pas