### PR TITLE
Upgrade slot system

### DIFF
--- a/app/assets/stylesheets/appointments.scss
+++ b/app/assets/stylesheets/appointments.scss
@@ -102,7 +102,7 @@
 
 .new-appointment-form-warning {
   text-align: center;
-  margin: 20px 0 50px;
+  margin: 20px 0;
 }
 
 .form-load-slots-button {

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,6 +1,7 @@
 class AppointmentsController < ApplicationController
   before_action :authenticate_user!
-  before_action :skip_authorization, only: [:display_places, :display_agendas, :display_slots, :display_slot_fields]
+  before_action :skip_authorization, only: [:display_places, :display_agendas, :display_time_options,
+                                            :display_slots, :display_slot_fields]
 
   def index
     @q = policy_scope(Appointment).active.ransack(params[:q])
@@ -76,22 +77,25 @@ class AppointmentsController < ApplicationController
   def display_places
     appointment_type = AppointmentType.find(params[:apt_type_id])
     @places = policy_scope(Place).joins(:appointment_types).where(appointment_types: appointment_type)
-
-    respond_to do |format|
-      format.js
-    end
   end
 
   def display_agendas
     place = policy_scope(Place).find(params[:place_id])
     @agendas = Agenda.where(place_id: place.id)
 
-    if @agendas.count == 1
-      redirect_to display_slots_path(agenda_id: @agendas.first.id, apt_type_id: params[:apt_type_id])
-    end
+    return unless @agendas.count == 1
 
-    respond_to do |format|
-      format.js
+    redirect_to display_slots_path(agenda_id: @agendas.first.id, apt_type_id: params[:apt_type_id])
+  end
+
+  def display_time_options
+    agenda = policy_scope(Agenda).find(params[:agenda_id])
+    @appointment_type = AppointmentType.find(params[:apt_type_id])
+
+    if @appointment_type.with_slot_types?
+      redirect_to display_slots_path(agenda_id: agenda.id, apt_type_id: @appointment_type.id)
+    else
+      redirect_to display_slot_fields_path(agenda_id: agenda.id, apt_type_id: @appointment_type.id)
     end
   end
 
@@ -99,25 +103,13 @@ class AppointmentsController < ApplicationController
     agenda = policy_scope(Agenda).find(params[:agenda_id])
     @appointment_type = AppointmentType.find(params[:apt_type_id])
 
-    unless @appointment_type.with_slot_types?
-      redirect_to display_slot_fields_path(agenda_id: agenda.id, apt_type_id: @appointment_type.id)
-    end
-
     @slots_by_date = Slot.future.relevant_and_available(agenda, @appointment_type)
                          .order(:date).group_by(&:date)
-
-    respond_to do |format|
-      format.js
-    end
   end
 
   def display_slot_fields
     @agenda = policy_scope(Agenda).find(params[:agenda_id])
     @appointment_type = AppointmentType.find(params[:apt_type_id])
-
-    respond_to do |format|
-      format.js
-    end
   end
 
   def index_today

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -99,7 +99,7 @@ class AppointmentsController < ApplicationController
     agenda = policy_scope(Agenda).find(params[:agenda_id])
     @appointment_type = AppointmentType.find(params[:apt_type_id])
 
-    unless @appointment_type.use_prebuild_slots?
+    unless @appointment_type.with_slot_types?
       redirect_to display_slot_fields_path(agenda_id: agenda.id, apt_type_id: @appointment_type.id)
     end
 

--- a/app/javascript/components/slot_selector.js
+++ b/app/javascript/components/slot_selector.js
@@ -51,7 +51,7 @@ function displayAgendas (place_id, appointment_type_id) {
 function displaySlots (agenda_id, appointment_type_id) {
   Rails.ajax({
     type: 'GET',
-    url: '/display_slots?agenda_id=' + agenda_id + '&apt_type_id=' + appointment_type_id,
+    url: '/display_time_options?agenda_id=' + agenda_id + '&apt_type_id=' + appointment_type_id,
     success: function() { allowSubmit(); }
   });
 }

--- a/app/javascript/components/slot_selector.js
+++ b/app/javascript/components/slot_selector.js
@@ -4,12 +4,18 @@ document.addEventListener('turbolinks:load',function() {
   const aptTypeSelect = document.getElementById('appointment_appointment_type_id');
   const slots_container = document.getElementById('slots-container');
   const agendas_container = document.getElementById('agendas-container');
+  const slot_fields_container = document.getElementById('slot-fields-container');
+
+  const submitButtonContainer = document.getElementById('before-submit-modal-option-container');
   const submitBtnWithSms = document.getElementById('btn-modal-with-sms');
   const submitBtnWithoutSms = document.getElementById('btn-modal-without-sms');
 
   aptTypeSelect.addEventListener('change', (e) => {
+    submitButtonContainer.style.display = 'none';
     if(agendas_container) { agendas_container.innerHTML = '';}
     if(slots_container) { slots_container.innerHTML = '';}
+    if(slot_fields_container) { slot_fields_container.innerHTML = '';}
+
     displayPlaces(aptTypeSelect.value);
   });
 
@@ -56,8 +62,10 @@ function addListenerToPlaceSelect() {
 
   const slots_container = document.getElementById('slots-container');
   const agendas_container = document.getElementById('agendas-container');
+  const submitButtonContainer = document.getElementById('before-submit-modal-option-container');
 
   placeSelect.addEventListener('change', (e) => {
+    submitButtonContainer.style.display = 'none';
     if(agendas_container) { agendas_container.innerHTML = '';}
     if(slots_container) { slots_container.innerHTML = '';}
 
@@ -68,12 +76,14 @@ function addListenerToPlaceSelect() {
 function addListenerToAgendaSelect() {
   const aptTypeSelect = document.getElementById('appointment_appointment_type_id');
   const agendaSelect = document.getElementById('appointment-form-agenda-select');
+  const submitButtonContainer = document.getElementById('before-submit-modal-option-container');
 
   if(agendaSelect == null) { allowSubmit(); return; }
 
   const slots_container = document.getElementById('slots-container');
 
   agendaSelect.addEventListener('change', (e) => {
+    submitButtonContainer.style.display = 'none';
     if(slots_container) { slots_container.innerHTML = '';}
 
     displaySlots(agendaSelect.value, aptTypeSelect.value);
@@ -82,11 +92,11 @@ function addListenerToAgendaSelect() {
 
 function allowSubmit () {
   const slotsFields = document.getElementsByName('appointment[slot_id]');
-  const showModalButtonContainer = document.getElementById('before-submit-modal-option-container');
+  const submitButtonContainer = document.getElementById('before-submit-modal-option-container');
 
   slotsFields.forEach(field => field.addEventListener('change', () => {
-    showModalButtonContainer.style.display = 'flex';
+    submitButtonContainer.style.display = 'flex';
   }));
 
-  if(slotsFields.length == 0) { showModalButtonContainer.style.display = 'flex'; }
+  if(slotsFields.length == 0) { submitButtonContainer.style.display = 'flex'; }
 }

--- a/app/javascript/components/slot_selector.js
+++ b/app/javascript/components/slot_selector.js
@@ -34,7 +34,7 @@ function displayPlaces (appointment_type_id) {
   });
 }
 
-function displayAgendas(place_id, appointment_type_id) {
+function displayAgendas (place_id, appointment_type_id) {
   Rails.ajax({
     type: 'GET',
     url: '/display_agendas?place_id=' + place_id + '&apt_type_id=' + appointment_type_id,
@@ -46,7 +46,7 @@ function displaySlots (agenda_id, appointment_type_id) {
   Rails.ajax({
     type: 'GET',
     url: '/display_slots?agenda_id=' + agenda_id + '&apt_type_id=' + appointment_type_id,
-    success: function() { allowSubmitOnSlotSelection(); }
+    success: function() { allowSubmit(); }
   });
 }
 
@@ -69,7 +69,7 @@ function addListenerToAgendaSelect() {
   const aptTypeSelect = document.getElementById('appointment_appointment_type_id');
   const agendaSelect = document.getElementById('appointment-form-agenda-select');
 
-  if(agendaSelect == null) { allowSubmitOnSlotSelection(); return; }
+  if(agendaSelect == null) { allowSubmit(); return; }
 
   const slots_container = document.getElementById('slots-container');
 
@@ -80,10 +80,13 @@ function addListenerToAgendaSelect() {
   });
 }
 
-function allowSubmitOnSlotSelection () {
+function allowSubmit () {
   const slotsFields = document.getElementsByName('appointment[slot_id]');
   const showModalButtonContainer = document.getElementById('before-submit-modal-option-container');
+
   slotsFields.forEach(field => field.addEventListener('change', () => {
     showModalButtonContainer.style.display = 'flex';
   }));
+
+  if(slotsFields.length == 0) { showModalButtonContainer.style.display = 'flex'; }
 }

--- a/app/models/agenda.rb
+++ b/app/models/agenda.rb
@@ -2,7 +2,6 @@ class Agenda < ApplicationRecord
   belongs_to :place
   has_many :slots, dependent: :destroy
   has_many :slot_types, dependent: :destroy
-  has_many :appointment_types, through: :slot_type
 
   validates :name, presence: true
 
@@ -12,4 +11,9 @@ class Agenda < ApplicationRecord
     joins(place: { organization: :areas_organizations_mappings })
       .where(areas_organizations_mappings: { area: department })
   }
+
+  def appointment_type_with_slot_types?
+    AppointmentType.where(id: slot_types.pluck(:appointment_type_id))
+                   .map(&:with_slot_types?).include?(true)
+  end
 end

--- a/app/models/agenda.rb
+++ b/app/models/agenda.rb
@@ -5,6 +5,8 @@ class Agenda < ApplicationRecord
 
   validates :name, presence: true
 
+  delegate :appointment_type_with_slot_types, to: :place
+
   scope :in_organization, ->(organization) { joins(:place).where(place: { organization: organization }) }
 
   scope :in_department, lambda { |department|
@@ -13,7 +15,6 @@ class Agenda < ApplicationRecord
   }
 
   def appointment_type_with_slot_types?
-    AppointmentType.where(id: slot_types.pluck(:appointment_type_id))
-                   .map(&:with_slot_types?).include?(true)
+    appointment_type_with_slot_types.length.positive?
   end
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -7,6 +7,8 @@ class Appointment < ApplicationRecord
   has_many :notifications, dependent: :destroy
   has_many :history_items, dependent: :destroy
 
+  accepts_nested_attributes_for :slot
+
   attr_accessor :place_id, :agenda_id
 
   enum origin_department: %i[bex gref_co pr]

--- a/app/models/appointment_type.rb
+++ b/app/models/appointment_type.rb
@@ -1,6 +1,8 @@
 class AppointmentType < ApplicationRecord
   has_paper_trail
 
+  WITH_SLOT_TYPES = ["Sortie d'audience SAP", "Sortie d'audience SPIP"].freeze
+
   has_many :notification_types, inverse_of: :appointment_type, dependent: :destroy
   has_many :slot_types, inverse_of: :appointment_type, dependent: :destroy
   has_many :slots
@@ -12,7 +14,7 @@ class AppointmentType < ApplicationRecord
 
   validates :name, presence: true
 
-  scope :with_slot_types, -> { all.select(&:with_slot_types?) }
+  scope :with_slot_types, -> { where name: WITH_SLOT_TYPES }
 
   def summon_notif
     notification_types.find_by(role: :summon)
@@ -51,7 +53,7 @@ class AppointmentType < ApplicationRecord
     if ENV['APP'] == 'mon-suivi-justice-prod'
       true
     else
-      ["Sortie d'audience SAP", "Sortie d'audience SPIP"].include? name
+      WITH_SLOT_TYPES.include? name
     end
   end
 end

--- a/app/models/appointment_type.rb
+++ b/app/models/appointment_type.rb
@@ -44,4 +44,8 @@ class AppointmentType < ApplicationRecord
     ["Sortie d'audience SPIP", '1er RDV SPIP', 'RDV de suivi SPIP', 'Convocation 741-1',
      'Placement TIG/TNR', 'Visite à domicile', 'RDV téléphonique', 'RDV pose DDSE', 'Convocation stage']
   end
+
+  def use_prebuild_slots?
+    ["Sortie d'audience SAP", "Sortie d'audience SPIP"].include? name
+  end
 end

--- a/app/models/appointment_type.rb
+++ b/app/models/appointment_type.rb
@@ -12,6 +12,8 @@ class AppointmentType < ApplicationRecord
 
   validates :name, presence: true
 
+  scope :with_slot_types, -> { all.select(&:with_slot_types?) }
+
   def summon_notif
     notification_types.find_by(role: :summon)
   end
@@ -46,6 +48,10 @@ class AppointmentType < ApplicationRecord
   end
 
   def with_slot_types?
-    ["Sortie d'audience SAP", "Sortie d'audience SPIP"].include? name
+    if ENV['APP'] == 'mon-suivi-justice-prod'
+      true
+    else
+      ["Sortie d'audience SAP", "Sortie d'audience SPIP"].include? name
+    end
   end
 end

--- a/app/models/appointment_type.rb
+++ b/app/models/appointment_type.rb
@@ -45,7 +45,7 @@ class AppointmentType < ApplicationRecord
      'Placement TIG/TNR', 'Visite à domicile', 'RDV téléphonique', 'RDV pose DDSE', 'Convocation stage']
   end
 
-  def use_prebuild_slots?
+  def with_slot_types?
     ["Sortie d'audience SAP", "Sortie d'audience SPIP"].include? name
   end
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -18,4 +18,8 @@ class Place < ApplicationRecord
     joins(organization: :areas_organizations_mappings)
       .where(areas_organizations_mappings: { area_type: 'Department', area_id: department.id })
   }
+
+  def appointment_type_with_slot_types
+    appointment_types.with_slot_types
+  end
 end

--- a/app/policies/appointment_policy.rb
+++ b/app/policies/appointment_policy.rb
@@ -40,7 +40,7 @@ class AppointmentPolicy < ApplicationPolicy
   end
 
   def create?
-    appointment_workflow
+    true
   end
 
   def destroy?

--- a/app/views/appointments/_display_slot_fields.html.erb
+++ b/app/views/appointments/_display_slot_fields.html.erb
@@ -1,0 +1,41 @@
+<div class="hidden appointment_slot_agenda_id">
+  <input class="hidden form-text-input" type="hidden" name="appointment[slot_attributes][agenda_id]" id="appointment_slot_agenda_id" value="<%= @agenda.id %>"/>
+</div>
+
+<div class="hidden appointment_slot_appointment_type_id">
+  <input class="hidden form-text-input" type="hidden" name="appointment[slot_attributes][appointment_type_id]" id="appointment_slot_appointment_type_id" value="<%= @appointment_type.id %>"/>
+</div>
+
+<div class="date required appointment_slot_date form-input-wrapper">
+  <label class="select required form-label" for="appointment-form-agenda-select">
+    <abbr title="required">*</abbr> <%= t('activerecord.attributes.slot.date') %>
+  </label>
+
+  <input class="form-text-input" type="date" name="appointment[slot_attributes][date]" id="appointment_slot_date"/>
+</div>
+
+<div class="time required appointment_slot_starting_time">
+  <div class="form-label">
+    <label class="time required form-label" for="appointment_slot_starting_time_4i">
+      <abbr title="required">*</abbr> <%= t('activerecord.attributes.slot.starting_time') %>
+    </label>
+  </div>
+
+  <div class="form-time-select-fields form-input-wrapper">
+    <input type="hidden" id="appointment_slot_starting_time_1i" name="appointment[slot_attributes][starting_time(1i)]" value="2022" />
+    <input type="hidden" id="appointment_slot_starting_time_2i" name="appointment[slot_attributes][starting_time(2i)]" value="1" />
+    <input type="hidden" id="appointment_slot_starting_time_3i" name="appointment[slot_attributes][starting_time(3i)]" value="20" />
+
+    <select id="appointment_slot_starting_time_4i" name="appointment[slot_attributes][starting_time(4i)]" class="time required form-text-input form-select" value="">
+      <% (7..20).each do |o| %>
+        <option value=<%= o %>><%= o %></option>
+      <% end %>
+    </select> :
+
+    <select id="appointment_slot_starting_time_5i" name="appointment[slot_attributes][starting_time(5i)]" class="time required form-text-input form-select" value="">
+      <% ['00', '05', '10', '15', '20', '25', '30', '35', '40', '45', '50', '55'].each do |o| %>
+        <option value=<%= o %>><%= o %></option>
+      <% end %>
+    </select>
+  </div>
+</div>

--- a/app/views/appointments/_display_slot_fields.html.erb
+++ b/app/views/appointments/_display_slot_fields.html.erb
@@ -11,7 +11,7 @@
     <abbr title="required">*</abbr> <%= t('activerecord.attributes.slot.date') %>
   </label>
 
-  <input class="form-text-input" type="date" name="appointment[slot_attributes][date]" id="appointment_slot_date"/>
+  <input class="form-text-input" type="date" name="appointment[slot_attributes][date]" id="appointment_slot_date" min=<%= Time.zone.now %>/>
 </div>
 
 <div class="time required appointment_slot_starting_time">

--- a/app/views/appointments/display_slot_fields.js.erb
+++ b/app/views/appointments/display_slot_fields.js.erb
@@ -1,0 +1,7 @@
+try {
+  slot_fields_container = document.getElementById('slot-fields-container');
+} catch (error) {
+  let slot_fields_container = document.getElementById('slot-fields-container');
+}
+
+slot_fields_container.innerHTML = "<%= j render partial: 'display_slot_fields', locals: {agenda: @agenda, appointment_type: @appointment_type} %>";

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -14,7 +14,7 @@
 <%= simple_form_for @appointment do |f| %>
   <div class='new-appointment-form'>
     <% if params.key?(:convict_id) %>
-      <%= f.input :convict_id, as: :hidden, input_html: { value: params[:convict_id] }  %>
+      <%= f.input :convict_id, as: :hidden, input_html: { value: params[:convict_id] } %>
     <% else %>
       <%= f.association :convict, collection: policy_scope(Convict.all),
                                   label: t('activerecord.models.convict'),
@@ -37,6 +37,7 @@
 
     <div class='appointment-form-places-container' id='places-container'></div>
     <div class='appointment-form-agendas-container' id='agendas-container'></div>
+    <div class='appointment-form-slot-fields-container' id='slot-fields-container'></div>
   </div>
 
   <div class='appointment-form-slots-container' id='slots-container'>

--- a/app/views/places/edit.html.erb
+++ b/app/views/places/edit.html.erb
@@ -39,7 +39,9 @@
       <% end %>
 
       <div class='edit-place-cta-container'>
-        <%= link_to t('edit_place_slot_types_agenda'), agenda_slot_types_path(agenda) %> |
+        <% if agenda.appointment_type_with_slot_types? %>
+          <%= link_to t('edit_place_slot_types_agenda'), agenda_slot_types_path(agenda) %> |
+        <% end %>
         <%= link_to t('edit_place_delete_agenda'), agenda_path(agenda), method: :delete %>
       </div>
     <% end %>

--- a/app/views/slot_types/index.html.erb
+++ b/app/views/slot_types/index.html.erb
@@ -5,7 +5,7 @@
 <p class='index-slot-types-warning'><%= t('index_slot_types_warning') %></p>
 
 <div class='slot-type-apt-type-link-container'>
-  <% @agenda.place.appointment_types.select(&:with_slot_types?).each do |apt_type| %>
+  <% @agenda.place.appointment_types.with_slot_types.each do |apt_type| %>
     <%= link_to apt_type.name, agenda_slot_types_path(@agenda, appointment_type_id: apt_type.id), class: "slot-type-apt-type-link-#{apt_type == @appointment_type}" %>
   <% end %>
 </div>

--- a/app/views/slot_types/index.html.erb
+++ b/app/views/slot_types/index.html.erb
@@ -5,7 +5,7 @@
 <p class='index-slot-types-warning'><%= t('index_slot_types_warning') %></p>
 
 <div class='slot-type-apt-type-link-container'>
-  <% @agenda.place.appointment_types.each do |apt_type| %>
+  <% @agenda.place.appointment_types.select(&:with_slot_types?).each do |apt_type| %>
     <%= link_to apt_type.name, agenda_slot_types_path(@agenda, appointment_type_id: apt_type.id), class: "slot-type-apt-type-link-#{apt_type == @appointment_type}" %>
   <% end %>
 </div>
@@ -108,7 +108,7 @@
             <%= link_to t('slot_types_batch_deletion'), agenda_slot_types_batch_path(@agenda, weekday: weekday),
                                                         method: :delete,
                                                         data: { confirm: t('slot_type_delete_confirmation') },
-                                                        class: 'slot-type-batch-delete-weekday-link'   %>
+                                                        class: 'slot-type-batch-delete-weekday-link' %>
           <% end %>
         </div>
 

--- a/app/views/slots/new.html.erb
+++ b/app/views/slots/new.html.erb
@@ -7,7 +7,7 @@
   <%= f.association :appointment_type, collection: AppointmentType.with_slot_types,
                                        label: t('activerecord.models.appointment_type'),
                                        input_html: { class: 'form-select' } %>
-  <%= f.input :date, input_html: { class: 'form-select' }, wrapper: :custom_date, start_year: 2022 %>
+  <%= f.input :date, input_html: { class: 'form-select' }, wrapper: :custom_date, start_year: Time.zone.now.year %>
   <%= f.input :starting_time, input_html: { class: 'form-select', value: f.object.starting_time.to_s },
                               wrapper: :custom_time,
                               start_hour: 7,

--- a/app/views/slots/new.html.erb
+++ b/app/views/slots/new.html.erb
@@ -7,7 +7,7 @@
   <%= f.association :appointment_type, collection: appointment_types_for_user(current_user),
                                        label: t('activerecord.models.appointment_type'),
                                        input_html: { class: 'form-select' } %>
-  <%= f.input :date, input_html: { class: 'form-select' }, wrapper: :custom_date, start_year: 2021 %>
+  <%= f.input :date, input_html: { class: 'form-select' }, wrapper: :custom_date, start_year: 2022 %>
   <%= f.input :starting_time, input_html: { class: 'form-select', value: f.object.starting_time.to_s },
                               wrapper: :custom_time,
                               start_hour: 7,

--- a/app/views/slots/new.html.erb
+++ b/app/views/slots/new.html.erb
@@ -4,7 +4,7 @@
   <%= f.association :agenda, collection: Agenda.in_organization(current_user.organization),
                              label: t('activerecord.models.agenda'),
                              input_html: { class: 'form-select' } %>
-  <%= f.association :appointment_type, collection: appointment_types_for_user(current_user),
+  <%= f.association :appointment_type, collection: AppointmentType.with_slot_types,
                                        label: t('activerecord.models.appointment_type'),
                                        input_html: { class: 'form-select' } %>
   <%= f.input :date, input_html: { class: 'form-select' }, wrapper: :custom_date, start_year: 2022 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,10 +34,12 @@ Rails.application.routes.draw do
     put 'excuse'
   end
 
+  get '/display_time_options' => 'appointments#display_time_options', as: 'display_time_options'
   get '/display_slots' => 'appointments#display_slots', as: 'display_slots'
+  get '/display_slot_fields' => 'appointments#display_slot_fields', as: 'display_slot_fields'
   get '/display_places' => 'appointments#display_places', as: 'display_places'
   get '/display_agendas' => 'appointments#display_agendas', as: 'display_agendas'
-  get '/display_slot_fields' => 'appointments#display_slot_fields', as: 'display_slot_fields'
+
   get '/today_appointments' => 'appointments#index_today', as: 'today_appointments'
   get '/stats' => redirect('https://infogram.com/column-stacked-chart-1h7z2l8www5rg6o?live', status: 302), as: :stats
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
   get '/display_slots' => 'appointments#display_slots', as: 'display_slots'
   get '/display_places' => 'appointments#display_places', as: 'display_places'
   get '/display_agendas' => 'appointments#display_agendas', as: 'display_agendas'
+  get '/display_slot_fields' => 'appointments#display_slot_fields', as: 'display_slot_fields'
   get '/today_appointments' => 'appointments#index_today', as: 'today_appointments'
   get '/stats' => redirect('https://infogram.com/column-stacked-chart-1h7z2l8www5rg6o?live', status: 302), as: :stats
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,7 +30,7 @@ SlotType.create(appointment_type: appointment_type1, agenda: agenda1, week_day: 
 place2 = Place.create!(organization: organization, name: "SPIP 92", adress: "94 Boulevard du Général Leclerc, 92000 Nanterre", phone: '0606060606')
 agenda2 = Agenda.create!(place: place2, name: "Agenda tribunal Ancenis")
 
-appointment_type2 = AppointmentType.create!(name: "Sortie d'audience SPIP")
+appointment_type2 = AppointmentType.create!(name: "RDV de suivi SPIP")
 PlaceAppointmentType.create!(place: place2, appointment_type: appointment_type2)
 
 NotificationType.create!(appointment_type: appointment_type2, role: :summon, template: "Vous êtes convoqué, merci de venir.")

--- a/spec/features/convicts_spec.rb
+++ b/spec/features/convicts_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature 'Convicts', type: :feature do
     end
 
     it 'creates a convict with his first appointment', js: true do
-      appointment_type = create(:appointment_type, :with_notification_types, name: 'Premier contact Spip')
+      appointment_type = create(:appointment_type, :with_notification_types, name: "Sortie d'audience SPIP")
       place = create(:place, name: 'McDo de Clichy', appointment_types: [appointment_type])
       agenda = create(:agenda, place: place, name: 'Agenda de Jean-Louis')
 
@@ -103,7 +103,7 @@ RSpec.feature 'Convicts', type: :feature do
       expect { click_button 'submit-with-appointment' }.to change { Convict.count }.by(1)
       expect(page).to have_current_path(new_appointment_path(convict_id: Convict.last.id))
 
-      select 'Premier contact Spip', from: :appointment_appointment_type_id
+      select "Sortie d'audience SPIP", from: :appointment_appointment_type_id
       select 'McDo de Clichy', from: 'Lieu'
       select 'Agenda de Jean-Louis', from: 'Agenda'
 

--- a/spec/features/slot_types_spec.rb
+++ b/spec/features/slot_types_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'SlotTypes', type: :feature do
 
     place = create :place, name: 'test_place_name'
     @agenda = create :agenda, place: place, name: 'test_agenda_name'
-    @appointment_type = create :appointment_type, name: 'apt_type_name'
+    @appointment_type = create :appointment_type, name: "Sortie d'audience SPIP"
     create :place_appointment_type, place: place, appointment_type: @appointment_type
     allow(Place).to receive(:in_department).and_return(Place.all)
   end
@@ -25,7 +25,7 @@ RSpec.feature 'SlotTypes', type: :feature do
 
       expect(page).to have_content 'Créneaux récurrents'
       expect(page).to have_content 'test_place_name : test_agenda_name'
-      expect(page).to have_content 'apt_type_name'
+      expect(page).to have_content "Sortie d'audience SPIP"
       expect(page).to have_css "#edit_slot_type_#{slot_type1.id}"
       expect(page).to have_css "#edit_slot_type_#{slot_type2.id}"
     end

--- a/spec/features/slots_spec.rb
+++ b/spec/features/slots_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Slots', type: :feature do
       within '.form-date-select-fields' do
         select '14', from: 'slot_date_3i'
         select 'octobre', from: 'slot_date_2i'
-        select '2021', from: 'slot_date_1i'
+        select '2024', from: 'slot_date_1i'
       end
 
       within first('.form-time-select-fields') do

--- a/spec/features/slots_spec.rb
+++ b/spec/features/slots_spec.rb
@@ -34,12 +34,14 @@ RSpec.feature 'Slots', type: :feature do
     it 'works' do
       place = create(:place, name: 'McDo de Clichy', organization: @user.organization)
       create(:agenda, place: place, name: 'Agenda de Michel')
-      create(:appointment_type, name: 'Premier contact Spip')
+      create(:appointment_type, name: "Sortie d'audience SPIP")
+      create(:appointment_type, name: 'RDV de suivi SPIP')
 
       visit new_slot_path
 
       select 'Agenda de Michel', from: 'Agenda'
-      select 'Premier contact Spip', from: 'Type de rendez-vous'
+      expect(page).to have_select('Type de rendez-vous', options: ['', "Sortie d'audience SPIP"])
+      select "Sortie d'audience SPIP", from: 'Type de rendez-vous'
 
       within '.form-date-select-fields' do
         select '14', from: 'slot_date_3i'

--- a/spec/models/agenda_spec.rb
+++ b/spec/models/agenda_spec.rb
@@ -23,13 +23,17 @@ RSpec.describe Agenda, type: :model do
   describe '#has_appointment_type_with_slot_types?' do
     it 'works' do
       apt_type1 = create(:appointment_type, name: "Sortie d'audience SPIP")
-      agenda1 = create(:agenda)
+      place1 = create(:place)
+      create(:place_appointment_type, place: place1, appointment_type: apt_type1)
+      agenda1 = create(:agenda, place: place1)
       create(:slot_type, appointment_type: apt_type1, agenda: agenda1)
 
       expect(agenda1.appointment_type_with_slot_types?).to eq true
 
       apt_type2 = create(:appointment_type, name: 'RDV de suivi SPIP')
-      agenda2 = create(:agenda)
+      place2 = create(:place)
+      create(:place_appointment_type, place: place2, appointment_type: apt_type2)
+      agenda2 = create(:agenda, place: place2)
       create(:slot_type, appointment_type: apt_type2, agenda: agenda2)
 
       expect(agenda2.appointment_type_with_slot_types?).to eq false

--- a/spec/models/agenda_spec.rb
+++ b/spec/models/agenda_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe Agenda, type: :model do
       expect(Agenda.in_organization(@organization)).to eq [@agenda_in]
     end
   end
+
+  describe '#has_appointment_type_with_slot_types?' do
+    it 'works' do
+      apt_type1 = create(:appointment_type, name: "Sortie d'audience SPIP")
+      agenda1 = create(:agenda)
+      create(:slot_type, appointment_type: apt_type1, agenda: agenda1)
+
+      expect(agenda1.appointment_type_with_slot_types?).to eq true
+
+      apt_type2 = create(:appointment_type, name: 'RDV de suivi SPIP')
+      agenda2 = create(:agenda)
+      create(:slot_type, appointment_type: apt_type2, agenda: agenda2)
+
+      expect(agenda2.appointment_type_with_slot_types?).to eq false
+    end
+  end
 end

--- a/spec/policies/appointment_policy_spec.rb
+++ b/spec/policies/appointment_policy_spec.rb
@@ -90,7 +90,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -145,7 +145,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: '1er RDV SPIP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -200,7 +200,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: '1er RDV SPIP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -240,7 +240,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -309,7 +309,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -364,7 +364,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -419,7 +419,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: '1er RDV SPIP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -474,7 +474,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: '1er RDV SPIP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -544,7 +544,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -614,7 +614,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -684,7 +684,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -754,7 +754,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -824,7 +824,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }
@@ -894,7 +894,7 @@ describe AppointmentPolicy do
       let(:appointment_type) { create(:appointment_type, name: 'RDV de suivi SAP') }
 
       it { is_expected.to permit_action(:new) }
-      it { is_expected.to forbid_action(:create) }
+      it { is_expected.to permit_action(:create) }
       it { is_expected.to forbid_action(:edit) }
       it { is_expected.to forbid_action(:update) }
       it { is_expected.to forbid_action(:destroy) }


### PR DESCRIPTION
Tout le système de créneau est limité aux types de rdv "Sortie d'audience SPIP" et "Sortie d'audience SAP".

Lors de la création d'un rdv, on a maintenant le choix entre deux modes de fonctionnement : 
- Complet, avec des créneaux issus de créneaux récurrents, pour les types de rdv "Sortie d'audience SPIP" et "Sortie d'audience SAP"
- Light, avec des champs pour saisir la date et l'heure du rdv directement

Dans la zone de gestion des créneaux récurrents, on ne peut plus en créer pour d'autres types de rdv que les deux prévus

Lors de la création d'un créneau, on ne peux choisir que les deux types de rdv adaptés.

