### PR TITLE
Remove organization variable from policies

### DIFF
--- a/app/policies/agenda_policy.rb
+++ b/app/policies/agenda_policy.rb
@@ -6,7 +6,7 @@ class AgendaPolicy < ApplicationPolicy
       elsif user.local_admin? || user.work_at_bex?
         scope.in_department(user.organization.departments.first)
       else
-        scope.in_organization(organization)
+        scope.in_organization(user.organization)
       end
     end
   end

--- a/app/policies/agenda_policy.rb
+++ b/app/policies/agenda_policy.rb
@@ -4,6 +4,8 @@ class AgendaPolicy < ApplicationPolicy
       if user.admin?
         scope.all
       elsif user.local_admin? || user.work_at_bex?
+        # TODO: there is for the moment only one department per organization.
+        # When there will be more, this logic will need to be adapted.
         scope.in_department(user.organization.departments.first)
       else
         scope.in_organization(user.organization)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -35,11 +35,10 @@ class ApplicationPolicy
   end
 
   class Scope
-    attr_reader :user, :scope, :organization
+    attr_reader :user, :scope
 
     def initialize(user, scope)
       @user = user
-      @organization = user&.organization
       @scope = scope
     end
 

--- a/app/policies/appointment_policy.rb
+++ b/app/policies/appointment_policy.rb
@@ -6,7 +6,7 @@ class AppointmentPolicy < ApplicationPolicy
       elsif user.local_admin? || user.work_at_bex?
         scope.in_department(user.organization.departments.first)
       else
-        scope.in_organization(organization)
+        scope.in_organization(user.organization)
       end
     end
   end

--- a/app/policies/appointment_policy.rb
+++ b/app/policies/appointment_policy.rb
@@ -4,6 +4,8 @@ class AppointmentPolicy < ApplicationPolicy
       if user.admin?
         scope.all
       elsif user.local_admin? || user.work_at_bex?
+        # TODO: there is for the moment only one department per organization.
+        # When there will be more, this logic will need to be adapted.
         scope.in_department(user.organization.departments.first)
       else
         scope.in_organization(user.organization)

--- a/app/policies/convict_policy.rb
+++ b/app/policies/convict_policy.rb
@@ -6,6 +6,8 @@ class ConvictPolicy < ApplicationPolicy
       if user.admin?
         scope.all
       elsif user.bex? || user.local_admin?
+        # TODO: there is for the moment only one department per organization.
+        # When there will be more, this logic will need to be adapted.
         scope.in_department(user.organization.departments.first)
       else
         scope.under_hand_of(user.organization)

--- a/app/policies/convict_policy.rb
+++ b/app/policies/convict_policy.rb
@@ -8,7 +8,7 @@ class ConvictPolicy < ApplicationPolicy
       elsif user.bex? || user.local_admin?
         scope.in_department(user.organization.departments.first)
       else
-        scope.under_hand_of(organization)
+        scope.under_hand_of(user.organization)
       end
     end
   end

--- a/app/policies/place_policy.rb
+++ b/app/policies/place_policy.rb
@@ -3,7 +3,6 @@ class PlacePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      raise
       if user.admin? || user.local_admin? || user.work_at_bex?
         scope.in_department(user.organization.departments.first)
       else

--- a/app/policies/place_policy.rb
+++ b/app/policies/place_policy.rb
@@ -4,6 +4,8 @@ class PlacePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       if user.admin? || user.local_admin? || user.work_at_bex?
+        # TODO: there is for the moment only one department per organization.
+        # When there will be more, this logic will need to be adapted.
         scope.in_department(user.organization.departments.first)
       else
         scope.in_organization(user.organization)

--- a/app/policies/place_policy.rb
+++ b/app/policies/place_policy.rb
@@ -3,10 +3,11 @@ class PlacePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
+      raise
       if user.admin? || user.local_admin? || user.work_at_bex?
         scope.in_department(user.organization.departments.first)
       else
-        scope.in_organization(organization)
+        scope.in_organization(user.organization)
       end
     end
   end

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -7,6 +7,8 @@
                             value: @q.slot_date_eq ? @q.slot_date_eq .strftime('%d/%m/%Y') : '',
                             placeholder: t('search-appointment-placeholder') %>
 
+        <%# TODO: there is for the moment only one department per organization.
+        When there will be more, this logic will need to be adapted. %>
         <%= f.select :slot_agenda_place_id_eq, options_from_collection_for_select(Place.in_department(current_user.organization.departments.first), 'id', 'name', @q.slot_agenda_place_id_eq),
                                                { include_blank: t('appointment_place') },
                                                { class: 'form-select index-place-filter-field' } %>

--- a/app/views/slots/index.html.erb
+++ b/app/views/slots/index.html.erb
@@ -7,6 +7,8 @@
                             value: @q.date_eq ? @q.date_eq.strftime('%d/%m/%Y') : '',
                             placeholder: t('search-appointment-placeholder') %>
 
+        <%# TODO: there is for the moment only one department per organization.
+        When there will be more, this logic will need to be adapted. %>
         <%= f.select :agenda_place_id_eq, options_from_collection_for_select(Place.in_department(current_user.organization.departments.first), 'id', 'name', @q.agenda_place_id_eq),
                                           { include_blank: t('index_slot_place_filter') },
                                           { class: 'form-select index-slot-filter-field' } %>


### PR DESCRIPTION
A priori on avait un agent non lié à un département. L'erreur n'est arrivée qu'une fois donc on peut laisser filer. Mais si ça arrive à nouveau faudra sans doute gérer des validations.

J'ai proposé malgré tout un petit changement car l'origine de la variable organization était assez peu claire de mon point de vue + elle n'était pas utiliser tout le temps.

Par contre, question: je trouve ça super étonnant dans les policies de n'afficher que les ressources liées au premier département d'une personne. Pourquoi ne pas lui afficher ressources liées à son organization? Si une personne doit avoir un département d'attache, il faudrait créer ce lien user/organization plutôt que de faire un `.first` non? Chaud pour avoir le contexte demain ;)

https://trello.com/c/r9UJufIN/763-https-sentryio-organizations-betagouv-f7-issues-2962840695-referreralertemailenvironmentproduction