### PR TITLE
WIP Guarder la position dans la page après avoir indiqué l'état d'un rdv sur Appointment#index

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,10 @@ class ApplicationController < ActionController::Base
     ENV['PUBLIC_SITE_ROOT']
   end
 
+  def back_with_anchor(anchor: '')
+    "#{request.referrer}##{anchor}"
+  end
+
   def current_organization
     @current_organization ||= current_user&.organization
   end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,4 +1,6 @@
 class AppointmentsController < ApplicationController
+  include ActionView::RecordIdentifier
+
   before_action :authenticate_user!
   before_action :skip_authorization, only: [:display_places, :display_agendas, :display_time_options,
                                             :display_slots, :display_slot_fields]
@@ -57,7 +59,7 @@ class AppointmentsController < ApplicationController
     @appointment.fulfil!
 
     authorize @appointment
-    redirect_back(fallback_location: root_path)
+    redirect_to back_with_anchor anchor: dom_id(@appointment))
   end
 
   def miss
@@ -65,7 +67,7 @@ class AppointmentsController < ApplicationController
     @appointment.miss!(send_notification: params[:send_sms])
 
     authorize @appointment
-    redirect_back(fallback_location: root_path)
+    redirect_to back_with_anchor anchor: dom_id(@appointment))
   end
 
   def excuse
@@ -73,7 +75,7 @@ class AppointmentsController < ApplicationController
     @appointment.excuse!
 
     authorize @appointment
-    redirect_back(fallback_location: root_path)
+    redirect_to back_with_anchor anchor: dom_id(@appointment))
   end
 
   def display_places

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -76,7 +76,7 @@
 
     <div class='index-list-container'>
       <% @appointments.each do |appointment| %>
-        <div class='index-list-line-container'>
+        <div class='index-list-line-container', id=<%= dom_id(appointment)%>>
           <div class='index-list-item-container'>
             <div class='appointments-column-1'>
               <%= appointment.convict.name %>


### PR DESCRIPTION
PB: Quand on clique sur les boutons qui indiquent l'état d'un rdv, on est renvoyé en haut de la page, et on perd la visibilité sur l'effet du changement de statut.

La solution discutée avec des anchor est en place, mais ça ne va pas : avec le bandeau en position fixed, l'anchor apparait derriere le bandeau, et le résultat est très perturbant.

On ne peut pas utiliser Turbolinks : les changements sont lancés par des button_to, pas des link_to. Turbolinks n'est pas activé.

Il reste la solution JS, comme décrit ici par ex : https://stackoverflow.com/a/51790464/3219759