### PR TITLE
Send sms when phone is added later

### DIFF
--- a/app/controllers/appointments_reschedules_controller.rb
+++ b/app/controllers/appointments_reschedules_controller.rb
@@ -39,6 +39,6 @@ class AppointmentsReschedulesController < AppointmentsController
     HistoryItem.order(created_at: :desc).where(appointment: appointment, event: 'cancel_appointment').first&.destroy
     HistoryItemFactory.perform(appointment: appointment, event: :reschedule_appointment, category: 'appointment')
     appointment.book send_notification: false
-    appointment.reschedule_notif.send_now if appointment.convict.phone.present?
+    appointment.reschedule_notif.send_now
   end
 end

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -5,6 +5,7 @@ class SmsDeliveryJob < ApplicationJob
 
   def perform(notification)
     return if notification.canceled?
+    return if notification.appointment.convict.phone.empty?
 
     notification.send_then if notification.programmed?
 

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -5,7 +5,7 @@ class SmsDeliveryJob < ApplicationJob
 
   def perform(notification)
     return if notification.canceled?
-    return if notification.appointment.convict.phone.empty?
+    return if notification.convict_phone.empty?
 
     notification.send_then if notification.programmed?
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -17,6 +17,7 @@ class Appointment < ApplicationRecord
   delegate :name, :adress, :phone, :contact_email, :main_contact_method,
            to: :place, prefix: true
   delegate :name, to: :organization, prefix: true
+  delegate :phone, to: :convict, prefix: true
 
   attr_accessor :place_id, :agenda_id, :user_is_cpip
 
@@ -151,9 +152,7 @@ class Appointment < ApplicationRecord
 
       appointment.transaction do
         NotificationFactory.perform(appointment)
-
-        send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
-        appointment.summon_notif.send_now! if send_sms
+        appointment.summon_notif.send_now! if send_sms?(transition)
         appointment.reminder_notif.program!
       end
     end
@@ -168,13 +167,11 @@ class Appointment < ApplicationRecord
         appointment.reminder_notif.cancel!
       end
 
-      send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
-      appointment.cancelation_notif.send_now! if send_sms
+      appointment.cancelation_notif.send_now! if send_sms?(transition)
     end
 
     after_transition on: :miss do |appointment, transition|
-      send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
-      appointment.no_show_notif&.send_now! if send_sms
+      appointment.no_show_notif&.send_now! if send_sms?(transition)
     end
 
     before_transition on: :rebook do |appointment, _|
@@ -184,6 +181,11 @@ class Appointment < ApplicationRecord
       history_item = appointment.history_items.where(event: "#{previous_event}_appointment".to_sym)
                                 .order(created_at: :desc).first
       history_item&.destroy
+    end
+
+    def send_sms?(transition)
+      # user can chose to send sms or not, this generates a boolean from a transition parameter
+      ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
     end
   end
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -151,10 +151,9 @@ class Appointment < ApplicationRecord
 
       appointment.transaction do
         NotificationFactory.perform(appointment)
-        if appointment.convict.phone?
-          send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
-          appointment.summon_notif.send_now! if send_sms
-        end
+
+        send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
+        appointment.summon_notif.send_now! if send_sms
         appointment.reminder_notif.program!
       end
     end
@@ -169,17 +168,13 @@ class Appointment < ApplicationRecord
         appointment.reminder_notif.cancel!
       end
 
-      if appointment.convict.phone?
-        send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
-        appointment.cancelation_notif.send_now! if send_sms
-      end
+      send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
+      appointment.cancelation_notif.send_now! if send_sms
     end
 
     after_transition on: :miss do |appointment, transition|
-      if appointment.convict.phone?
-        send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
-        appointment.no_show_notif&.send_now! if send_sms
-      end
+      send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
+      appointment.no_show_notif&.send_now! if send_sms
     end
 
     before_transition on: :rebook do |appointment, _|

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -154,8 +154,8 @@ class Appointment < ApplicationRecord
         if appointment.convict.phone?
           send_sms = ActiveModel::Type::Boolean.new.cast(transition&.args&.first&.dig(:send_notification))
           appointment.summon_notif.send_now! if send_sms
-          appointment.reminder_notif.program!
         end
+        appointment.reminder_notif.program!
       end
     end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -6,6 +6,8 @@ class Notification < ApplicationRecord
 
   attr_readonly :content
 
+  delegate :convict_phone, to: :appointment
+
   enum role: %i[summon reminder cancelation no_show reschedule]
   enum reminder_period: %i[one_day two_days]
 

--- a/spec/factories/convict.rb
+++ b/spec/factories/convict.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     first_name { 'Jane' }
     last_name { 'Doe' }
     sequence(:phone, 2) { |n| "060606060#{n}" }
+    no_phone { false }
   end
 end

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature 'Notifications', type: :feature do
+  before do
+    @user = create_admin_user_and_login
+    allow(Place).to receive(:in_department).and_return(Place.all)
+  end
+
+  describe 'Reminder' do
+    let(:adapter_dbl) { instance_double SendinblueAdapter, send_sms: true }
+
+    it "is programmed even if the convict don't have a phone", js: true do
+      allow(SendinblueAdapter).to receive(:new).and_return adapter_dbl
+
+      convict = create(:convict, first_name: 'Bobby', last_name: 'Lapointe', phone: '', no_phone: true)
+      create :areas_convicts_mapping, convict: convict, area: @user.organization.departments.first
+      appointment_type = create :appointment_type, :with_notification_types, name: 'RDV de suivi SPIP'
+      place = create :place, name: 'SPIP de Thorigné', appointment_types: [appointment_type],
+                             organization: @user.organization
+      create :agenda, place: place, name: 'Agenda du SPIP de Thorigné'
+
+      visit new_appointment_path
+
+      first('.select2-container', minimum: 1).click
+      find('li.select2-results__option', text: 'LAPOINTE Bobby').click
+
+      select 'RDV de suivi SPIP', from: :appointment_appointment_type_id
+      select 'SPIP de Thorigné', from: 'Lieu'
+
+      fill_in 'appointment_slot_date', with: (Date.civil(2025, 4, 18)).strftime('%Y-%m-%d')
+
+      within first('.form-time-select-fields') do
+        select '15', from: 'appointment_slot_starting_time_4i'
+        select '00', from: 'appointment_slot_starting_time_5i'
+      end
+
+      click_button 'Enregistrer'
+      click_button 'Non'
+
+      expect(SmsDeliveryJob).to have_been_enqueued.once
+    end
+  end
+end

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -6,17 +6,8 @@ RSpec.describe SmsDeliveryJob, type: :job do
   let(:notification) { create :notification, appointment: appointment }
 
   context 'with a phone number' do
-    describe '#perform_later' do
-      let(:tested_method) { SmsDeliveryJob.perform_later(notification) }
-
-      it 'queues the job' do
-        tested_method
-        expect(SmsDeliveryJob).to have_been_enqueued.once.with(notification)
-      end
-    end
-
     describe '#perform' do
-      let(:tested_method) { SmsDeliveryJob.new.perform(notification) }
+      let(:tested_method) { SmsDeliveryJob.perform_now(notification) }
       let(:adapter_dbl) { instance_double SendinblueAdapter, send_sms: true }
 
       before do
@@ -39,29 +30,17 @@ RSpec.describe SmsDeliveryJob, type: :job do
   end
 
   context 'without a phone number' do
-    before do
-      convict.update(phone: '')
-    end
-
-    describe '#perform_later' do
-      let(:tested_method) { SmsDeliveryJob.perform_later(notification) }
-
-      it 'queues the job' do
-        tested_method
-        expect(SmsDeliveryJob).to have_been_enqueued.once.with(notification)
-      end
-    end
-
     describe '#perform' do
-      let(:tested_method) { SmsDeliveryJob.new.perform(notification) }
+      let(:tested_method) { SmsDeliveryJob.perform_now(notification) }
       let(:adapter_dbl) { instance_double SendinblueAdapter, send_sms: true }
 
       before do
+        convict.update(phone: '')
         allow(SendinblueAdapter).to receive(:new).and_return adapter_dbl
         tested_method
       end
 
-      it 'instantiates SendinblueAdapter' do
+      it "don't instantiates SendinblueAdapter" do
         expect(SendinblueAdapter).not_to have_received(:new)
       end
 

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -1,34 +1,77 @@
 require 'rails_helper'
 
 RSpec.describe SmsDeliveryJob, type: :job do
-  let(:notification) { create :notification }
+  let(:convict) { create :convict, phone: '+33606060606' }
+  let(:appointment) { create :appointment, convict: convict }
+  let(:notification) { create :notification, appointment: appointment }
 
-  describe '#perform_later' do
-    let(:tested_method) { SmsDeliveryJob.perform_later(notification) }
+  context 'with a phone number' do
+    describe '#perform_later' do
+      let(:tested_method) { SmsDeliveryJob.perform_later(notification) }
 
-    it 'queues the job' do
-      tested_method
-      expect(SmsDeliveryJob).to have_been_enqueued.once.with(notification)
+      it 'queues the job' do
+        tested_method
+        expect(SmsDeliveryJob).to have_been_enqueued.once.with(notification)
+      end
+    end
+
+    describe '#perform' do
+      let(:tested_method) { SmsDeliveryJob.new.perform(notification) }
+      let(:adapter_dbl) { instance_double SendinblueAdapter, send_sms: true }
+
+      before do
+        allow(SendinblueAdapter).to receive(:new).and_return adapter_dbl
+        tested_method
+      end
+
+      it 'instantiates SendinblueAdapter' do
+        expect(SendinblueAdapter).to have_received(:new).once
+      end
+
+      it 'send sms' do
+        expect(adapter_dbl).to have_received(:send_sms).once.with(notification)
+      end
+
+      it 'get sms events' do
+        expect(GetSmsStatusJob).to have_been_enqueued.once.with(notification.id)
+      end
     end
   end
 
-  describe '#perform' do
-    let(:tested_method) { SmsDeliveryJob.new.perform(notification) }
-    let(:adapter_dbl) { instance_double SendinblueAdapter, send_sms: true }
-
+  context 'without a phone number' do
     before do
-      allow(SendinblueAdapter).to receive(:new).and_return adapter_dbl
-      tested_method
+      convict.update(phone: '')
     end
 
-    it 'instantiates SendinblueAdapter' do
-      expect(SendinblueAdapter).to have_received(:new).once
+    describe '#perform_later' do
+      let(:tested_method) { SmsDeliveryJob.perform_later(notification) }
+
+      it 'queues the job' do
+        tested_method
+        expect(SmsDeliveryJob).to have_been_enqueued.once.with(notification)
+      end
     end
-    it 'send sms' do
-      expect(adapter_dbl).to have_received(:send_sms).once.with(notification)
-    end
-    it 'get sms events' do
-      expect(GetSmsStatusJob).to have_been_enqueued.once.with(notification.id)
+
+    describe '#perform' do
+      let(:tested_method) { SmsDeliveryJob.new.perform(notification) }
+      let(:adapter_dbl) { instance_double SendinblueAdapter, send_sms: true }
+
+      before do
+        allow(SendinblueAdapter).to receive(:new).and_return adapter_dbl
+        tested_method
+      end
+
+      it 'instantiates SendinblueAdapter' do
+        expect(SendinblueAdapter).not_to have_received(:new)
+      end
+
+      it "don't send sms" do
+        expect(adapter_dbl).not_to have_received(:send_sms)
+      end
+
+      it "don't get sms events" do
+        expect(GetSmsStatusJob).not_to have_been_enqueued
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/S1PxPguD/809-proposer-denvoyer-un-sms-de-rappel-lorsquon-ajoute-un-num%C3%A9ro-de-tel-%C3%A0-une-ppsmj-dont-le-rdv-avait-%C3%A9t%C3%A9-fix%C3%A9-sans-num%C3%A9ro