### PR TITLE
First draft destroy interface from Agents app

### DIFF
--- a/app/jobs/destroy_convict_interface_job.rb
+++ b/app/jobs/destroy_convict_interface_job.rb
@@ -1,0 +1,8 @@
+class DestroyConvictInterfaceJob < ApplicationJob
+  sidekiq_options retry: 5
+  queue_as :default
+
+  def perform(convict_id)
+    MonSuiviJusticePublicApi::Convict.destroy(convict_id)
+  end
+end

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -3,6 +3,8 @@ class Convict < ApplicationRecord
   include Discard::Model
   has_paper_trail
 
+  after_destroy :destroy_convict_interface
+
   WHITELISTED_PHONES = %w[+33659763117 +33683481555 +33682356466 +33603371085
                           +33687934479 +33674426177 +33616430756 +33613254126].freeze
 
@@ -117,5 +119,9 @@ class Convict < ApplicationRecord
     return if duplicates.empty?
 
     errors.add :phone, I18n.t('activerecord.errors.models.convict.attributes.phone.taken')
+  end
+
+  def destroy_convict_interface
+    DestroyConvictInterfaceJob.perform_now(id)
   end
 end

--- a/app/services/mon_suivi_justice_public_api/convict.rb
+++ b/app/services/mon_suivi_justice_public_api/convict.rb
@@ -1,0 +1,9 @@
+module MonSuiviJusticePublicApi
+  class Convict < Base
+    class << self
+      def destroy(id)
+        connection.delete("#{BASE_URL}/convict/#{id}", 'Content-Type': 'application/json')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Tout premier draft pour le déclenchement de la destruction de l'interface PPSMJ côté app agents.

- Pas de tests pour l'instant + il faudra stubber le nouveau call API pour les tests existants qui détruisent un convict
- Choix de ne pas détruire l'interface au moment de l'archivage mais seulement de la destruction du convict (car les convicts sont détruits quoi qu'il arrive 6 mois après l'archivage)
