### PR TITLE
Feature/appt status modification before starting time

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -63,7 +63,7 @@ class Appointment < ApplicationRecord
   end
 
   def in_the_past?
-    slot.date <= Date.today
+    slot.starting_time.strftime('%H:%M') <= Time.now.strftime('%H:%M')
   end
 
   def datetime

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -63,7 +63,7 @@ class Appointment < ApplicationRecord
   end
 
   def in_the_past?
-    slot.starting_time.strftime('%H:%M') <= Time.now.strftime('%H:%M')
+    date <= Date.today && starting_time.strftime('%H:%M') <= Time.now.strftime('%H:%M')
   end
 
   def datetime

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -80,6 +80,7 @@ class Convict < ApplicationRecord
     appointments.joins(:slot)
                 .where(state: 'booked')
                 .where('slots.date': ..Date.today)
+                .where('starting_time::time < ?', Time.now)
   end
 
   def mobile_phone_number

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -79,8 +79,14 @@ class Convict < ApplicationRecord
   def passed_appointments
     appointments.joins(:slot)
                 .where(state: 'booked')
-                .where('slots.date': ..Date.today)
-                .where('starting_time::time < ?', Time.now)
+                .where('slots.date < ?', Date.today).or(passed_today_appointments)
+  end
+
+  def passed_today_appointments
+    appointments.joins(:slot)
+                .where(state: 'booked')
+                .where('slots.date = ?', Date.today)
+                .where('starting_time <= ?', Time.now.strftime('%H:%M'))
   end
 
   def mobile_phone_number

--- a/app/views/convicts/show.html.erb
+++ b/app/views/convicts/show.html.erb
@@ -2,7 +2,7 @@
 
 <% if @convict.passed_appointments.present? %>
   <% policy_scope(@convict.passed_appointments).each do |apt| %>
-    <% if apt.booked? && policy(apt).fulfil?%>
+    <% if apt.booked? && policy(apt).fulfil? %>
       <div class='appointment-fulfilment-container'>
         <div class='appointment-fulfilment-prompt-container'>
           <%= t('show-convict-fulfilment-prompt', name: @convict.name,

--- a/spec/features/appointments_spec.rb
+++ b/spec/features/appointments_spec.rb
@@ -490,7 +490,8 @@ RSpec.feature 'Appointments', type: :feature do
       create :areas_convicts_mapping, convict: convict, area: @user.organization.departments.first
 
       apt_type = create :appointment_type, :with_notification_types
-      slot = create :slot, date: Date.civil(2025, 4, 14), appointment_type: apt_type
+      slot = create :slot, date: Date.civil(2025, 4, 14), starting_time: Time.now - 1.minutes,
+                           appointment_type: apt_type
       appointment = create :appointment, convict: convict, slot: slot
 
       appointment.book
@@ -504,7 +505,8 @@ RSpec.feature 'Appointments', type: :feature do
       convict = create :convict
       create :areas_convicts_mapping, convict: convict, area: @user.organization.departments.first
       apt_type = create :appointment_type, :with_notification_types
-      slot = create :slot, :without_validations, date: Date.today, appointment_type: apt_type
+      slot = create :slot, :without_validations, date: Date.today, starting_time: Time.now - 1.minutes,
+                                                 appointment_type: apt_type
       appointment = create :appointment, convict: convict, slot: slot
 
       appointment.book
@@ -539,7 +541,8 @@ RSpec.feature 'Appointments', type: :feature do
         create :areas_convicts_mapping, convict: convict, area: @user.organization.departments.first
 
         apt_type = create :appointment_type, :with_notification_types
-        slot = create :slot, :without_validations, date: Date.today, appointment_type: apt_type
+        slot = create :slot, :without_validations, date: Date.today, starting_time: Time.now - 1.minutes,
+                                                   appointment_type: apt_type
         appointment = create :appointment, convict: convict, slot: slot
 
         appointment.book
@@ -558,7 +561,8 @@ RSpec.feature 'Appointments', type: :feature do
         convict = create(:convict, first_name: 'babar', last_name: 'bobor')
         create :areas_convicts_mapping, convict: convict, area: @user.organization.departments.first
         apt_type = create(:appointment_type, :with_notification_types)
-        slot = create :slot, :without_validations, date: Date.today, appointment_type: apt_type
+        slot = create :slot, :without_validations, date: Date.today, starting_time: Time.now - 1.minutes,
+                                                   appointment_type: apt_type
         appointment = create :appointment, convict: convict, slot: slot
 
         appointment.book
@@ -577,7 +581,8 @@ RSpec.feature 'Appointments', type: :feature do
         convict = create :convict
         create :areas_convicts_mapping, convict: convict, area: @user.organization.departments.first
         apt_type = create :appointment_type, :with_notification_types
-        slot = create :slot, :without_validations, date: Date.today, appointment_type: apt_type
+        slot = create :slot, :without_validations, date: Date.today, starting_time: Time.now - 1.minutes,
+                                                   appointment_type: apt_type
         appointment = create :appointment, convict: convict, slot: slot
 
         appointment.book

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Appointment, type: :model do
     before { allow(Date).to receive(:today).and_return frozen_date }
 
     it 'returns true if appointment is in the past' do
-      slot = Slot.new(date: Date.new(2018, 1, 1))
+      slot = Slot.new(date: Date.new(2018, 1, 1), starting_time: Time.now - 1.minutes)
       appointment = Appointment.new(slot: slot)
 
       expect(appointment.in_the_past?).to eq(true)


### PR DESCRIPTION
Users cannot set the status of an appointment until starting_time is passed.