### PR TITLE
Feature/modification tableau sortie audience spip

### DIFF
--- a/app/assets/stylesheets/bex.scss
+++ b/app/assets/stylesheets/bex.scss
@@ -109,7 +109,23 @@
 .jap-agenda-header7 { background-color: $jap-cabinet7; }
 
 .spip-date-select {
-  width: 220px;
+  width: 140px;
+
+  @media print {
+    width: inherit;
+  }
+}
+
+.spip-place-select {
+  width: 300px;
+
+  @media print {
+    width: inherit;
+  }
+}
+
+.spip-agenda-select {
+  width: 300px;
 
   @media print {
     width: inherit;
@@ -143,5 +159,12 @@
 }
 
 .bex-filters-container select {
-  margin: 5px;
+  margin: 0px;
+}
+
+.bex-form-input-wrapper {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 20px;
+  margin-left: 10px;
 }

--- a/app/assets/stylesheets/bex.scss
+++ b/app/assets/stylesheets/bex.scss
@@ -109,7 +109,7 @@
 .jap-agenda-header7 { background-color: $jap-cabinet7; }
 
 .spip-date-select {
-  width: 170px;
+  width: 220px;
 
   @media print {
     width: inherit;
@@ -135,4 +135,13 @@
 
 .bex-agenda-case-prepared-form {
   margin: auto;
+}
+
+.bex-filters-container form {
+  display: flex;
+  justify-content: space-between;
+}
+
+.bex-filters-container select {
+  margin: 5px;
 }

--- a/app/controllers/bex_controller.rb
+++ b/app/controllers/bex_controller.rb
@@ -19,7 +19,7 @@ class BexController < ApplicationController
   def agenda_spip
     @appointment_type = AppointmentType.find_by(name: "Sortie d'audience SPIP")
     @current_date = current_date(@appointment_type, params)
-    get_spip_agendas(@appointment_type, params)
+    get_places_and_agendas(@appointment_type, params)
 
     respond_to do |format|
       format.html
@@ -56,8 +56,11 @@ class BexController < ApplicationController
     end
   end
 
-  def get_spip_agendas(appointment_type, params)
-    @agendas = policy_scope(Agenda).with_open_slots(appointment_type)
+  def get_places_and_agendas(appointment_type, params)
+    @places = policy_scope(Place).kept.joins(:appointment_types).where(appointment_types: appointment_type)
+    @place = params[:place_id] ? Place.find(params[:place_id]) : @places.first
+
+    @agendas = policy_scope(Agenda).where(place: @place).with_open_slots(appointment_type)
     @agenda = params[:agenda_id] ? Agenda.find(params[:agenda_id]) : @agendas.first
   end
 end

--- a/app/controllers/bex_controller.rb
+++ b/app/controllers/bex_controller.rb
@@ -61,6 +61,6 @@ class BexController < ApplicationController
     @place = params[:place_id] ? Place.find(params[:place_id]) : @places.first
 
     @agendas = policy_scope(Agenda).where(place: @place).with_open_slots(appointment_type)
-    @agenda = params[:agenda_id] ? Agenda.find(params[:agenda_id]) : @agendas.first
+    @agenda = params[:agenda_id] != nil ? Agenda.find(params[:agenda_id]) : @agendas.first
   end
 end

--- a/app/controllers/bex_controller.rb
+++ b/app/controllers/bex_controller.rb
@@ -61,6 +61,6 @@ class BexController < ApplicationController
     @place = params[:place_id] ? Place.find(params[:place_id]) : @places.first
 
     @agendas = policy_scope(Agenda).where(place: @place).with_open_slots(appointment_type)
-    @agenda = params[:agenda_id] != nil ? Agenda.find(params[:agenda_id]) : @agendas.first
+    @agenda = params[:agenda_id].nil? ? @agendas.first : Agenda.find(params[:agenda_id])
   end
 end

--- a/app/controllers/bex_controller.rb
+++ b/app/controllers/bex_controller.rb
@@ -19,7 +19,9 @@ class BexController < ApplicationController
   def agenda_spip
     @appointment_type = AppointmentType.find_by(name: "Sortie d'audience SPIP")
     @current_date = current_date(@appointment_type, params)
-    @agenda = policy_scope(Agenda).with_open_slots(@appointment_type).first
+
+    @agendas = policy_scope(Agenda).with_open_slots(@appointment_type)
+    @agenda = params[:agenda_id] ? Agenda.find(params[:agenda_id]) : @agendas.first
 
     respond_to do |format|
       format.html

--- a/app/controllers/bex_controller.rb
+++ b/app/controllers/bex_controller.rb
@@ -19,9 +19,7 @@ class BexController < ApplicationController
   def agenda_spip
     @appointment_type = AppointmentType.find_by(name: "Sortie d'audience SPIP")
     @current_date = current_date(@appointment_type, params)
-
-    @agendas = policy_scope(Agenda).with_open_slots(@appointment_type)
-    @agenda = params[:agenda_id] ? Agenda.find(params[:agenda_id]) : @agendas.first
+    get_spip_agendas(@appointment_type, params)
 
     respond_to do |format|
       format.html
@@ -56,5 +54,10 @@ class BexController < ApplicationController
     else
       current_organization.first_day_with_slots(appointment_type)
     end
+  end
+
+  def get_spip_agendas(appointment_type, params)
+    @agendas = policy_scope(Agenda).with_open_slots(appointment_type)
+    @agenda = params[:agenda_id] ? Agenda.find(params[:agenda_id]) : @agendas.first
   end
 end

--- a/app/dashboards/agenda_dashboard.rb
+++ b/app/dashboards/agenda_dashboard.rb
@@ -69,7 +69,7 @@ class AgendaDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how agendas are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(agenda)
-  #   "Agenda ##{agenda.id}"
-  # end
+  def display_resource(agenda)
+    "#{agenda.name}"
+  end
 end

--- a/app/dashboards/agenda_dashboard.rb
+++ b/app/dashboards/agenda_dashboard.rb
@@ -70,6 +70,6 @@ class AgendaDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(agenda)
-    "#{agenda.name}"
+    agenda.name.to_s
   end
 end

--- a/app/dashboards/appointment_type_dashboard.rb
+++ b/app/dashboards/appointment_type_dashboard.rb
@@ -78,7 +78,7 @@ class AppointmentTypeDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how appointment types are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(appointment_type)
-  #   "AppointmentType ##{appointment_type.id}"
-  # end
+  def display_resource(appointment_type)
+    "#{appointment_type.name}"
+  end
 end

--- a/app/dashboards/appointment_type_dashboard.rb
+++ b/app/dashboards/appointment_type_dashboard.rb
@@ -79,6 +79,6 @@ class AppointmentTypeDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(appointment_type)
-    "#{appointment_type.name}"
+    appointment_type.name.to_s
   end
 end

--- a/app/dashboards/slot_dashboard.rb
+++ b/app/dashboards/slot_dashboard.rb
@@ -63,16 +63,13 @@ class SlotDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     agenda
     appointment_type
-    appointments
     available
     capacity
     date
     duration
     full
-    slot_type
     starting_time
     used_capacity
-    versions
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/views/admin/users/_collection.html.erb
+++ b/app/views/admin/users/_collection.html.erb
@@ -93,7 +93,6 @@ to display a collection of resources in an HTML table.
           "Impersonate",
           admin_user_impersonate_path(resource),
           class: "text-color-red",
-          data: { confirm: t("administrate.actions.confirm") }
         ) %></td>
         <% end %>
       </tr>

--- a/app/views/bex/agenda_spip.html.erb
+++ b/app/views/bex/agenda_spip.html.erb
@@ -2,7 +2,7 @@
   <div class='bex-agendas-tools-container'>
     <%= button_to t('print_button'), agenda_spip_path(format: :pdf),
                                      method: :get,
-                                     params: {date: params[:date]},
+                                     params: {date: params[:date], agenda_id: params[:agenda_id]},
                                      form: { target: '_blank' },
                                      class: 'bex-print-button' %>
   </div>
@@ -11,12 +11,16 @@
     <div class='bex-date-title-container'>
       <%= t('bex.spip.appointments_title') %>
     </div>
-    <div class='bex-date-select-container'>
+    <div class='bex-filters-container'>
       <%= form_tag agenda_spip_path, method: 'get' do %>
         <%= select_tag :date, options_for_select(formated_month_for_select(six_next_months), params[:date]),
                                id: 'spip-appointments-month-select',
                                class: 'form-select form-text-input spip-date-select',
                                onchange: 'this.form.submit()' %>
+
+        <% if @agendas.count > 1 %>
+          <%= select_tag :agenda_id, options_from_collection_for_select(@agendas, 'id', 'name', @agenda.id), class: 'form-select form-text-input', onchange: 'this.form.submit()' %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/bex/agenda_spip.html.erb
+++ b/app/views/bex/agenda_spip.html.erb
@@ -2,7 +2,7 @@
   <div class='bex-agendas-tools-container'>
     <%= button_to t('print_button'), agenda_spip_path(format: :pdf),
                                      method: :get,
-                                     params: {date: params[:date], agenda_id: params[:agenda_id]},
+                                     params: {date: params[:date], agenda_id: @agenda.id, place_id: @place.id},
                                      form: { target: '_blank' },
                                      class: 'bex-print-button' %>
   </div>
@@ -13,13 +13,25 @@
     </div>
     <div class='bex-filters-container'>
       <%= form_tag agenda_spip_path, method: 'get' do %>
-        <%= select_tag :date, options_for_select(formated_month_for_select(six_next_months), params[:date]),
-                               id: 'spip-appointments-month-select',
-                               class: 'form-select form-text-input spip-date-select',
-                               onchange: 'this.form.submit()' %>
+        <div class="bex-form-input-wrapper">
+          <%= label_tag 'date', 'Date :' %>
+          <%= select_tag :date, options_for_select(formated_month_for_select(six_next_months), params[:date]),
+                                id: 'spip-appointments-month-select',
+                                class: 'form-select form-text-input spip-date-select',
+                                onchange: 'this.form.submit()' %>
+        </div>
 
+        <% if @places.count > 0 %>
+          <div class="bex-form-input-wrapper">
+            <%= label_tag 'place_id', 'Lieu :' %>
+            <%= select_tag :place_id, options_from_collection_for_select(@places, 'id', 'name', @place.id), class: 'form-select form-text-input spip-place-select', onchange: 'this.form.submit()' %>
+          </div>
+        <% end %>
         <% if @agendas.count > 1 %>
-          <%= select_tag :agenda_id, options_from_collection_for_select(@agendas, 'id', 'name', @agenda.id), class: 'form-select form-text-input', onchange: 'this.form.submit()' %>
+          <div class="bex-form-input-wrapper">
+            <%= label_tag 'agenda_id', 'Agenda :' %>
+            <%= select_tag :agenda_id, options_from_collection_for_select(@agendas, 'id', 'name', @agenda.id), class: 'form-select form-text-input spip-agenda-select', onchange: 'this.form.submit()' %>
+          </div>
         <% end %>
       <% end %>
     </div>

--- a/app/views/bex/agenda_spip_pdf.html.erb
+++ b/app/views/bex/agenda_spip_pdf.html.erb
@@ -1,6 +1,6 @@
 <%= image_tag wicked_pdf_asset_base64('logo_msj.svg') %>
 <h1 class='pdf-bex-title'><%= t('pdf.bex-spip.title') %></h1>
-<div class='bex-agenda-date'><%= (I18n.l date, format: '%B %Y').capitalize %> - <%= @agenda.name %></div>
+<div class='bex-agenda-date'><%= (I18n.l date, format: '%B %Y').capitalize %> - <%= @place.name %> - <%= @agenda.name %></div>
 
 <% if @agenda.nil? %>
   <p class='bex-agenda-spip-no-agenda'><%= t('bex.spip.no_agenda_available') %></p>

--- a/app/views/bex/agenda_spip_pdf.html.erb
+++ b/app/views/bex/agenda_spip_pdf.html.erb
@@ -1,6 +1,6 @@
 <%= image_tag wicked_pdf_asset_base64('logo_msj.svg') %>
 <h1 class='pdf-bex-title'><%= t('pdf.bex-spip.title') %></h1>
-<div class='bex-agenda-date'><%= (I18n.l date, format: '%B %Y').capitalize %></div>
+<div class='bex-agenda-date'><%= (I18n.l date, format: '%B %Y').capitalize %> - <%= @agenda.name %></div>
 
 <% if @agenda.nil? %>
   <p class='bex-agenda-spip-no-agenda'><%= t('bex.spip.no_agenda_available') %></p>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -509,7 +509,7 @@ fr:
       header_case_prepared: "Traité"
     spip:
       appointments_link: "Agenda RDV SPIP"
-      appointments_title: "Agenda RDV SPIP pour"
+      appointments_title: "RDV SPIP pour"
       no_agenda_available: "Pas de rdv Sortie d'audience SPIP prévu"
     sap_ddse:
       agendas_title: "Agenda SAP DDSE pour le"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
       resources :convicts
       resources :organizations
       resources :departments
-      resources :slots, except: :index
+      resources :slots
       resources :places, except: :index
       resources :jurisdictions, except: :index
       if Rails.env.development?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,8 @@ FRENCH_JURISDICTIONS.each do |name|
 end
 
 org_spip_92 = Organization.create!(name: 'SPIP 92', organization_type: 'spip')
+org_spip_61_argentan = Organization.create!(name: 'SPIP 61 - Argentan', organization_type: 'spip')
+org_spip_61_alencon = Organization.create!(name: 'SPIP 61 - Alençon', organization_type: 'spip')
 org_tj_nanterre = Organization.create!(name: 'TJ Nanterre', organization_type: 'tj')
 org_spip_75 = Organization.create!(name: 'SPIP 75', organization_type: 'spip')
 org_spip_77 = Organization.create!(name: 'SPIP 77', organization_type: 'spip')
@@ -17,6 +19,8 @@ org_tj_fontainebleau = Organization.create!(name: 'TJ de Fontainebleau', organiz
 # Cela impacte le rattachement des ppsmj à tel  département et/ou juridiction à leur création
 AreasOrganizationsMapping.create organization: org_spip_92, area: Department.find_by(number: '92')
 AreasOrganizationsMapping.create organization: org_spip_92, area: Jurisdiction.find_by(name: 'TJ NANTERRE')
+AreasOrganizationsMapping.create organization: org_spip_61_argentan, area: Department.find_by(number: '61')
+AreasOrganizationsMapping.create organization: org_spip_61_alencon, area: Department.find_by(number: '61')
 AreasOrganizationsMapping.create organization: org_tj_nanterre, area: Department.find_by(number: '92')
 
 AreasOrganizationsMapping.create organization: org_spip_75, area: Department.find_by(number: '75')
@@ -35,7 +39,6 @@ convict_3 = Convict.create!(first_name: "Bobba", last_name: "Smet", phone: "0611
 convict_4 = Convict.create!(first_name: "Conor", last_name: "McGregor", phone: "0611111112", appi_uuid: "12348")
 convict_5 = Convict.create!(first_name: "Georges", last_name: "Saint-Pierre", phone: "0611111113", appi_uuid: "12349")
 
-
 AreasConvictsMapping.create convict: convict_1, area: Department.find_by(number: '92')
 AreasConvictsMapping.create convict: convict_2, area: Department.find_by(number: '92')
 AreasConvictsMapping.create convict: convict_2, area: Jurisdiction.find_by(name: 'TJ NANTERRE')
@@ -45,7 +48,6 @@ AreasConvictsMapping.create convict: convict_5, area: Department.find_by(number:
 AreasConvictsMapping.create convict: convict_4, area: Jurisdiction.find_by(name: 'TJ MELUN')
 AreasConvictsMapping.create convict: convict_5, area: Jurisdiction.find_by(name: 'TJ FONTAINEBLEAU')
 
-
 User.create!(
         organization: org_spip_92, email: 'admin@example.com', password: '1mot2passeSecurise!',
         password_confirmation: '1mot2passeSecurise!', role: :admin, first_name: 'Kevin', last_name: 'McCallister'
@@ -54,6 +56,26 @@ User.create!(
 User.create!(
   organization: org_spip_92, email: 'cpip@example.com', password: '1mot2passeSecurise!',
   password_confirmation: '1mot2passeSecurise!', role: :cpip, first_name: 'Bob', last_name: 'Dupneu'
+)
+
+User.create!(
+  organization: org_spip_61_argentan, email: 'cpip61argentan@example.com', password: '1mot2passeSecurise!',
+  password_confirmation: '1mot2passeSecurise!', role: :cpip, first_name: 'Sylvain', last_name: 'Chabrier'
+)
+
+User.create!(
+  organization: org_spip_61_argentan, email: 'localadmin61argentan@example.com', password: '1mot2passeSecurise!',
+  password_confirmation: '1mot2passeSecurise!', role: :local_admin, first_name: 'Jacques', last_name: 'Chirac'
+)
+
+User.create!(
+  organization: org_spip_61_alencon, email: 'cpip61alencon@example.com', password: '1mot2passeSecurise!',
+  password_confirmation: '1mot2passeSecurise!', role: :cpip, first_name: 'Tom', last_name: 'Aouate'
+)
+
+User.create!(
+  organization: org_spip_61_alencon, email: 'localadmin61alencon@example.com', password: '1mot2passeSecurise!',
+  password_confirmation: '1mot2passeSecurise!', role: :local_admin, first_name: 'François', last_name: 'Hollande'
 )
 
 User.create!(
@@ -132,6 +154,9 @@ place_spip_77_permanence_tj = Place.create!(
 
 place_spip_92 = Place.create!(organization: org_spip_92, name: "SPIP 92", adress: "94 Boulevard du Général Leclerc, 92000 Nanterre", phone: '0606060606')
 
+place_spip_61_argentan = Place.create!(organization: org_spip_61_argentan, name: "SPIP 61 - Argentan", adress: "17 avenue de l'Industrie, 61200 Argentan", phone: '0606060606')
+place_spip_61_alencon = Place.create!(organization: org_spip_61_alencon, name: "SPIP 61 - Alencon", adress: "4 Ter rue des Poulies, 61007 Alençon", phone: '0606060606')
+
 agenda_tj_nanterre = Agenda.create!(place: place_tj_nanterre, name: "Agenda 1 tribunal Nanterre")
 agenda_tj_nanterre_2 = Agenda.create!(place: place_tj_nanterre, name: "Agenda 2 tribunal Nanterre")
 
@@ -152,6 +177,8 @@ apt_type_sortie_audience_spip = AppointmentType.create!(name: "Sortie d'audience
 PlaceAppointmentType.create!(place: place_tj_nanterre, appointment_type: apt_type_sortie_audience_sap)
 PlaceAppointmentType.create!(place: place_tj_nanterre, appointment_type: apt_type_rdv_suivi_jap)
 PlaceAppointmentType.create!(place: place_spip_92, appointment_type: apt_type_rdv_suivi_spip)
+PlaceAppointmentType.create!(place: place_spip_61_alencon, appointment_type: apt_type_rdv_suivi_spip)
+PlaceAppointmentType.create!(place: place_spip_61_argentan, appointment_type: apt_type_rdv_suivi_spip)
 PlaceAppointmentType.create!(place: place_spip_92, appointment_type: apt_type_sortie_audience_spip)
 
 PlaceAppointmentType.create!(place: place_tj_melun, appointment_type: apt_type_rdv_suivi_jap)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -142,6 +142,7 @@ agenda_spip_75 = Agenda.create!(place: place_spip_75, name: "Agenda SPIP 75")
 agenda_spip_92 = Agenda.create!(place: place_spip_92, name: "Agenda SPIP 92")
 agenda_spip_77 = Agenda.create!(place: place_spip_77, name: "Agenda SPIP 77")
 agenda_spip_77_permanence_tj = Agenda.create!(place: place_spip_77_permanence_tj, name: "Permanence TJ Fontainebleau")
+agenda_spip_77_permanence_tj_2 = Agenda.create!(place: place_spip_77_permanence_tj, name: "Permanence TJ Fontainebleau 2")
 
 apt_type_sortie_audience_sap = AppointmentType.create!(name: "Sortie d'audience SAP")
 apt_type_rdv_suivi_jap = AppointmentType.create!(name: 'RDV de suivi JAP')
@@ -187,11 +188,12 @@ NotificationType.create!(appointment_type: apt_type_sortie_audience_spip, role: 
 SlotType.create(appointment_type: apt_type_sortie_audience_spip, agenda: agenda_spip_92, week_day: :monday, starting_time: Time.new(2021, 6, 21, 10, 00, 0), duration: 60, capacity: 3)
 SlotType.create(appointment_type: apt_type_sortie_audience_spip, agenda: agenda_spip_92, week_day: :monday, starting_time: Time.new(2021, 6, 21, 11, 00, 0), duration: 60, capacity: 3)
 SlotType.create(appointment_type: apt_type_sortie_audience_sap, agenda: agenda_tj_nanterre, week_day: :wednesday, starting_time: Time.new(2021, 6, 21, 10, 00, 0), duration: 60, capacity: 3)
-SlotType.create(appointment_type: apt_type_sortie_audience_sap, agenda: agenda_tj_nanterre, week_day: :wednesday, starting_time: Time.new(2021, 6, 21, 11, 00, 0), duration: 60, capacity: 3)
+SlotType.create(appointment_type: apt_type_sortie_audience_sap, agenda: agenda_tj_nanterre_2, week_day: :wednesday, starting_time: Time.new(2021, 6, 21, 11, 00, 0), duration: 60, capacity: 3)
 SlotType.create(appointment_type: apt_type_sortie_audience_sap, agenda: agenda_tj_melun, week_day: :monday, starting_time: Time.new(2021, 6, 21, 10, 00, 0), duration: 60, capacity: 3)
 SlotType.create(appointment_type: apt_type_sortie_audience_sap, agenda: agenda_tj_fontainebleau, week_day: :tuesday, starting_time: Time.new(2021, 6, 21, 11, 00, 0), duration: 60, capacity: 3)
 SlotType.create(appointment_type: apt_type_sortie_audience_spip, agenda: agenda_spip_77, week_day: :monday, starting_time: Time.new(2021, 6, 21, 11, 00, 0), duration: 60, capacity: 3)
 SlotType.create(appointment_type: apt_type_sortie_audience_spip, agenda: agenda_spip_77_permanence_tj, week_day: :monday, starting_time: Time.new(2021, 6, 21, 11, 00, 0), duration: 60, capacity: 3)
+SlotType.create(appointment_type: apt_type_sortie_audience_spip, agenda: agenda_spip_77_permanence_tj_2, week_day: :monday, starting_time: Time.new(2021, 6, 21, 11, 00, 0), duration: 60, capacity: 3)
 
 SlotFactory.perform
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -141,7 +141,7 @@ agenda_tj_fontainebleau = Agenda.create!(place: place_tj_fontainebleau, name: "A
 agenda_spip_75 = Agenda.create!(place: place_spip_75, name: "Agenda SPIP 75")
 agenda_spip_92 = Agenda.create!(place: place_spip_92, name: "Agenda SPIP 92")
 agenda_spip_77 = Agenda.create!(place: place_spip_77, name: "Agenda SPIP 77")
-agenda_spip_77_permanence_tj = Agenda.create!(place: place_spip_92, name: "Permanence TJ Fontainebleau")
+agenda_spip_77_permanence_tj = Agenda.create!(place: place_spip_77_permanence_tj, name: "Permanence TJ Fontainebleau")
 
 apt_type_sortie_audience_sap = AppointmentType.create!(name: "Sortie d'audience SAP")
 apt_type_rdv_suivi_jap = AppointmentType.create!(name: 'RDV de suivi JAP')

--- a/scalingo.json
+++ b/scalingo.json
@@ -5,7 +5,7 @@
       }
     },
   "scripts": {
-      "first-deploy": "bin/rails db:schema:load db:migrate",
-      "postdeploy": "bin/rails db:migrate db:seed"
+      "first-deploy": "bin/rails db:schema:load db:migrate db:seed",
+      "postdeploy": "bin/rails db:migrate"
     }
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,11 +1,11 @@
 {
-    "env": {
-        "IS_REVIEW_APP": {
-          "value": "true"
-        }
-      },
-    "scripts": {
-        "first-deploy": "bin/rails db:schema:load db:migrate",
-        "postdeploy": "bin/rails db:migrate"
+  "env": {
+      "IS_REVIEW_APP": {
+        "value": "true"
       }
+    },
+  "scripts": {
+      "first-deploy": "bin/rails db:schema:load db:migrate",
+      "postdeploy": "bin/rails db:migrate db:seed"
+    }
 }

--- a/spec/features/bex_spec.rb
+++ b/spec/features/bex_spec.rb
@@ -142,6 +142,9 @@ RSpec.feature 'Bex', type: :feature do
 
       place = create(:place, name: 'SPIP 91', organization: @organization)
 
+      create(:place_appointment_type, place: place, appointment_type: apt_type)
+
+
       agenda = create(:agenda, place: place, name: 'Agenda SPIP 91')
 
       slot1 = create(:slot, :without_validations, agenda: agenda,

--- a/spec/features/bex_spec.rb
+++ b/spec/features/bex_spec.rb
@@ -144,7 +144,6 @@ RSpec.feature 'Bex', type: :feature do
 
       create(:place_appointment_type, place: place, appointment_type: apt_type)
 
-
       agenda = create(:agenda, place: place, name: 'Agenda SPIP 91')
 
       slot1 = create(:slot, :without_validations, agenda: agenda,


### PR DESCRIPTION
- Permet aux agents du spip de consulter plusieurs agendas sur la page qui liste les rendez-vous de sortie d'audience spip.
- Ajouts à la seed permettant d'illustrer cette situation
- Modification de l'affichage de certaines ressources dans les dashboards d'administration