### PR TITLE
removed available condition in slots for date

### DIFF
--- a/app/models/agenda.rb
+++ b/app/models/agenda.rb
@@ -33,7 +33,6 @@ class Agenda < ApplicationRecord
   def slots_for_date(date, appointment_type)
     slots.where(date: date, appointment_type: appointment_type)
          .order(:date, :starting_time)
-         .available
          .uniq
   end
 end


### PR DESCRIPTION
Relates to https://www.notion.so/monsuivijustice/Visibilit-cr-neaux-sortie-d-audience-9bc8aa2c522542ecb473f8ec4f44962a

Lorsqu'on fermait un créneau alors qu'un ou plusieurs rdv étaient déjà pris dessus, alors ces rendez-vous n'apparaissaient plus sur l'agenda sortie d'audience jap.

<img width="1672" alt="Capture d’écran 2022-11-22 à 10 10 32" src="https://user-images.githubusercontent.com/25039335/203274051-f7386ff7-e54a-4454-ab69-48b323c5415f.png">
<img width="1669" alt="Capture d’écran 2022-11-22 à 10 11 09" src="https://user-images.githubusercontent.com/25039335/203274065-65a9fc9c-48f1-4941-bdc9-6c6bcc271015.png">
