### PR TITLE
now selecting first 20 slots instead of 10

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -21,7 +21,7 @@ class Organization < ApplicationRecord
         .pluck(:date)
         .uniq
         .sort
-        .first(10)
+        .first(20)
   end
 
   def first_day_with_slots(appointment_type)


### PR DESCRIPTION
Relates to https://www.notion.so/monsuivijustice/Augmenter-le-nombre-de-date-du-select-agenda-JAP-20-dates-au-lieu-de-10-0098d0a7cd1d41278d4741636ef3c05a

<img width="1208" alt="Capture d’écran 2022-11-29 à 10 16 21" src="https://user-images.githubusercontent.com/25039335/204488657-78d0c817-55e5-4a46-b033-17b38d78ed50.png">
