### PR TITLE
Feature/nouveaux filtres sortie audience jap

### DIFF
--- a/app/assets/stylesheets/appointments.scss
+++ b/app/assets/stylesheets/appointments.scss
@@ -210,7 +210,6 @@
 
 .jap-agendas-modal-trigger {
   @include button($light-grey);
-  margin: 5px;
 }
 
 .jap-agendas-modal-close {

--- a/app/controllers/bex_controller.rb
+++ b/app/controllers/bex_controller.rb
@@ -5,7 +5,19 @@ class BexController < ApplicationController
   def agenda_jap
     @appointment_type = AppointmentType.find_by(name: "Sortie d'audience SAP")
     @current_date = current_date(@appointment_type, params)
-    @agendas = policy_scope(Agenda).kept.with_open_slots_for_date(@current_date, @appointment_type)
+
+
+
+    @selected_month_dates = Slot.future
+    .in_organization(current_user.organization)
+    .where(appointment_type: @appointment_type, date: @current_date.all_month.to_a)
+    .pluck(:date)
+    .uniq
+    .sort
+
+
+    get_places_and_agendas(@appointment_type, params)
+
 
     respond_to do |format|
       format.html

--- a/app/controllers/bex_controller.rb
+++ b/app/controllers/bex_controller.rb
@@ -1,37 +1,28 @@
 class BexController < ApplicationController
   before_action :authenticate_user!
+  before_action :appointment_type
+  before_action :month, only: :agenda_jap
   skip_after_action :verify_authorized
 
   def agenda_jap
-    @appointment_type = AppointmentType.find_by(name: "Sortie d'audience SAP")
-    @current_date = current_date(@appointment_type, params)
+    get_jap_agendas(@appointment_type, params)
 
-
-
-    @selected_month_dates = Slot.future
-    .in_organization(current_user.organization)
-    .where(appointment_type: @appointment_type, date: @current_date.all_month.to_a)
-    .pluck(:date)
-    .uniq
-    .sort
-
-
-    get_places_and_agendas(@appointment_type, params)
-
+    @days_with_slots_in_selected_month = days_with_slots(@appointment_type, params[:month])
+    @selected_day = selected_day(@days_with_slots_in_selected_month, params)
 
     respond_to do |format|
       format.html
       format.pdf do
-        render template: 'bex/agenda_jap_pdf.html.erb', locals: { date: @current_date },
+        render template: 'bex/agenda_jap_pdf.html.erb', locals: { date: @selected_day },
                pdf: "Agenda sortie d'audience JAP", footer: { right: '[page]/[topage]' }
       end
     end
   end
 
   def agenda_spip
-    @appointment_type = AppointmentType.find_by(name: "Sortie d'audience SPIP")
     @current_date = current_date(@appointment_type, params)
-    get_places_and_agendas(@appointment_type, params)
+
+    get_spip_places_and_agendas(@appointment_type, params)
 
     respond_to do |format|
       format.html
@@ -43,7 +34,6 @@ class BexController < ApplicationController
   end
 
   def agenda_sap_ddse
-    @appointment_type = AppointmentType.find_by(name: 'SAP DDSE')
     @current_date = current_date(@appointment_type, params)
     @agendas = policy_scope(Agenda).with_open_slots_for_date(@current_date, @appointment_type)
 
@@ -58,6 +48,14 @@ class BexController < ApplicationController
 
   private
 
+  def month
+    params[:month] ||= Date.today
+  end
+
+  def appointment_type
+    @appointment_type = AppointmentType.find_by(name: params[:appointment_type])
+  end
+
   def current_date(appointment_type, params)
     if params.key?(:date) && !params[:date].empty?
       params[:date].to_date
@@ -68,11 +66,38 @@ class BexController < ApplicationController
     end
   end
 
-  def get_places_and_agendas(appointment_type, params)
+  def places(appointment_type)
+    policy_scope(Place).kept.joins(:appointment_types).where(appointment_types: appointment_type)
+  end
+
+  def get_jap_agendas(appointment_type, params)
+    @places_agendas = policy_scope(Agenda).where(place: places(appointment_type)).with_open_slots(appointment_type)
+    @selected_agenda = Agenda.find(params[:agenda_id]) unless params[:agenda_id].blank?
+    @agendas_to_display = @selected_agenda.nil? ? @places_agendas : [@selected_agenda]
+  end
+
+  def get_spip_places_and_agendas(appointment_type, params)
     @places = policy_scope(Place).kept.joins(:appointment_types).where(appointment_types: appointment_type)
     @place = params[:place_id] ? Place.find(params[:place_id]) : @places.first
 
     @agendas = policy_scope(Agenda).where(place: @place).with_open_slots(appointment_type)
     @agenda = params[:agenda_id].nil? ? @agendas.first : Agenda.find(params[:agenda_id])
+  end
+
+  def days_with_slots(appointment_type, month)
+    Slot.future
+        .in_organization(current_organization)
+        .where(appointment_type: appointment_type, date: month.to_date.all_month.to_a)
+        .pluck(:date)
+        .uniq
+        .sort
+  end
+
+  def selected_day(days_with_slots_in_selected_month, params)
+    if params.key?(:date) && !params[:date].empty? && (params[:date] != params[:day])
+      params[:date].to_date
+    else
+      days_with_slots_in_selected_month.first
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
     formated = []
 
     date_array.each do |date|
-      formated << [(I18n.l date, format: '%d %D').capitalize, date]
+      formated << [(I18n.l date, format: '%A %d').capitalize, date]
     end
 
     formated

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,16 @@ module ApplicationHelper
     formated
   end
 
+  def formated_days_for_select(date_array)
+    formated = []
+
+    date_array.each do |date|
+      formated << [(I18n.l date, format: '%d %D').capitalize, date]
+    end
+
+    formated
+  end
+
   def ten_next_open_days
     twenty_next_days = (Date.today..Date.today + 20).to_a
     open_days = twenty_next_days.select { |d| !d.on_weekend? && Holidays.on(d, :fr) == [] }

--- a/app/views/bex/agenda_jap.html.erb
+++ b/app/views/bex/agenda_jap.html.erb
@@ -13,7 +13,7 @@
 
     <%= button_to t('print_button'), agenda_jap_path(format: :pdf),
                                      method: :get,
-                                     params: { date: params[:date] },
+                                     params: { date: @selected_day, month: params[:month], agenda_id: params[:agenda_id] },
                                      form: { target: '_blank' },
                                      class: 'bex-print-button' %>
   </div>

--- a/app/views/bex/agenda_jap.html.erb
+++ b/app/views/bex/agenda_jap.html.erb
@@ -35,7 +35,7 @@
             <div class="bex-form-input-wrapper">
               <%= label_tag 'day', 'Jour :' %>
               <%= select_tag :date, options_for_select(formated_days_for_select(@days_with_slots_in_selected_month), params[:date]),
-                                    id: 'spip-appointments-month-select',
+                                    id: 'jap-appointments-date-select',
                                     class: 'form-select form-text-input spip-date-select',
                                     onchange: 'this.form.submit()' %>
             </div>

--- a/app/views/bex/agenda_jap.html.erb
+++ b/app/views/bex/agenda_jap.html.erb
@@ -17,150 +17,137 @@
                                      form: { target: '_blank' },
                                      class: 'bex-print-button' %>
   </div>
-
-  <% if @agendas.empty? %>
-    <p class='bex-agenda-spip-no-agenda'><%= t('bex.jap.no_agenda_available') %></p>
-  <% else %>
     <div class='bex-agendas-date-container'>
       <div class='bex-date-title-container'>
         <%= t('bex.jap.agendas_title') %>
       </div>
       <div class='bex-filters-container'>
-        <%= form_tag agenda_jap_path, method: 'get' do %>
+        <%= form_tag agenda_jap_path, method: 'post' do %>
           <div class="bex-form-input-wrapper">
             <%= label_tag 'month', 'Mois :' %>
-            <%= select_tag :month, options_for_select(formated_month_for_select(six_next_months), params[:date]),
+            <%= select_tag :month, options_for_select(formated_month_for_select(six_next_months), params[:month]),
                                   id: 'spip-appointments-month-select',
                                   class: 'form-select form-text-input spip-date-select',
                                   onchange: 'this.form.submit()' %>
           </div>
+
+          <% if !@days_with_slots_in_selected_month.empty? %>
+            <div class="bex-form-input-wrapper">
+              <%= label_tag 'day', 'Jour :' %>
+              <%= select_tag :date, options_for_select(formated_days_for_select(@days_with_slots_in_selected_month), params[:date]),
+                                    id: 'spip-appointments-month-select',
+                                    class: 'form-select form-text-input spip-date-select',
+                                    onchange: 'this.form.submit()' %>
+            </div>
+          <% end %>
+          <%= hidden_field_tag :day, @selected_day %>
 
           <div class="bex-form-input-wrapper">
-            <%= label_tag 'day', 'Jour :' %>
-            <%= select_tag :date, options_for_select(formated_days_for_select(@selected_month_dates), params[:date]),
-                                  id: 'spip-appointments-month-select',
-                                  class: 'form-select form-text-input spip-date-select',
-                                  onchange: 'this.form.submit()' %>
+            <%= label_tag 'agenda_id', 'Agenda :' %>
+            <%= select_tag :agenda_id, options_from_collection_for_select(@places_agendas, 'id', 'name', params[:agenda_id]), prompt: 'Tous les agendas', class: 'form-select form-text-input spip-agenda-select', onchange: 'this.form.submit()' %>
           </div>
-
-
-          <% if @places.count > 0 %>
-            <div class="bex-form-input-wrapper">
-              <%= label_tag 'place_id', 'Lieu :' %>
-              <%= select_tag :place_id, options_from_collection_for_select(@places, 'id', 'name', @place.id), class: 'form-select form-text-input spip-place-select', onchange: 'this.form.submit()' %>
-            </div>
-          <% end %>
-          <% if @agendas.count > 1 %>
-            <div class="bex-form-input-wrapper">
-              <%= label_tag 'agenda_id', 'Agenda :' %>
-              <%= select_tag :agenda_id, options_from_collection_for_select(@agendas, 'id', 'name', @agenda.id), class: 'form-select form-text-input spip-agenda-select', onchange: 'this.form.submit()' %>
-            </div>
-          <% end %>
-
-
-
-
-
-  
         <% end %>
       </div>
     </div>
 
-    <% @agendas.each_with_index do |agenda, index| %>
-      <% unless agenda.slots_for_date(@current_date, @appointment_type).count.zero? %>
-        <div class='bex-agenda-container'>
-          <div class='bex-agenda-header jap-agenda-header<%= index+1%>'>
-            <div class='bex-agenda-header-title'>
-              <%= agenda.name %>
+    <% if @days_with_slots_in_selected_month.empty? %>
+      <p class='bex-agenda-spip-no-agenda'>Aucun créneau pour le mois sélectionné</p>
+    <% else %>
+      <% @agendas_to_display.each_with_index do |agenda, index| %>
+        <% unless agenda.slots_for_date(@selected_day, @appointment_type).count.zero? %>
+          <div class='bex-agenda-container'>
+            <div class='bex-agenda-header jap-agenda-header<%= index+1%>'>
+              <div class='bex-agenda-header-title'>
+                <%= agenda.name %>
+              </div>
             </div>
-          </div>
 
-          <div class='bex-agenda-table'>
-            <div class='bex-agenda-table-header bex-agenda-line'>
-              <div class='bex-agenda-header-title bex-agenda-small-column'>
-                <%= t('bex.jap.header_hour') %>
-              </div>
-              <div class='bex-agenda-header-title bex-agenda-column'>
-                <%= t('bex.jap.header_last_name') %>
-              </div>
-              <div class='bex-agenda-header-title bex-agenda-column'>
-                <%= t('bex.jap.header_first_name') %>
-              </div>
-              <div class='bex-agenda-header-title bex-agenda-column'>
-                <%= t('bex.jap.header_prosecutor') %>
-              </div>
-              <div class='bex-agenda-header-title bex-agenda-column'>
-                <%= t('bex.jap.header_origin') %>
-              </div>
-              <div class='bex-agenda-header-title bex-agenda-column'>
-                <%= t('bex.jap.header_role') %>
-              </div>
-              <% if current_user.work_at_bex? || current_user.admin? %>
+            <div class='bex-agenda-table'>
+              <div class='bex-agenda-table-header bex-agenda-line'>
                 <div class='bex-agenda-header-title bex-agenda-small-column'>
-                  <%= t('bex.jap.header_case_prepared') %>
+                  <%= t('bex.jap.header_hour') %>
                 </div>
-              <% end %>
-            </div>
+                <div class='bex-agenda-header-title bex-agenda-column'>
+                  <%= t('bex.jap.header_last_name') %>
+                </div>
+                <div class='bex-agenda-header-title bex-agenda-column'>
+                  <%= t('bex.jap.header_first_name') %>
+                </div>
+                <div class='bex-agenda-header-title bex-agenda-column'>
+                  <%= t('bex.jap.header_prosecutor') %>
+                </div>
+                <div class='bex-agenda-header-title bex-agenda-column'>
+                  <%= t('bex.jap.header_origin') %>
+                </div>
+                <div class='bex-agenda-header-title bex-agenda-column'>
+                  <%= t('bex.jap.header_role') %>
+                </div>
+                <% if current_user.work_at_bex? || current_user.admin? %>
+                  <div class='bex-agenda-header-title bex-agenda-small-column'>
+                    <%= t('bex.jap.header_case_prepared') %>
+                  </div>
+                <% end %>
+              </div>
 
-            <% agenda.slots_for_date(@current_date, @appointment_type).each do |slot| %>
-              <% appointments = slot.appointments.active %>
-              <% slot.capacity.times do |i| %>
-                <div class='bex-agenda-line'>
-                  <div class='bex-agenda-small-column'>
-                    <% if i == 0 %>
-                      <%= slot.localized_time.to_s(:lettered) %>
-                    <% end %>
-                  </div>
-                  <div class='bex-agenda-column'>
-                    <% unless appointments[i].nil? %>
-                      <%= link_to convict_path(appointments[i]&.convict), class: 'index-control' do %>
-                        <%= appointments[i]&.convict&.last_name&.upcase %>
-                      <% end %>
-                    <% end %>
-                  </div>
-                  <div class='bex-agenda-column'>
-                    <%= appointments[i]&.convict&.first_name %>
-                  </div>
-                  <div class='bex-agenda-column'>
-                    <%= appointments[i]&.prosecutor_number %>
-                  </div>
-                  <div class='bex-agenda-column'>
-                    <% if appointments[i].present? && appointments[i].creating_organization.present? %>
-                      <%= appointments[i].creating_organization.name %>
-                    <% elsif appointments[i].present? && appointments[i].inviter_user_id.present? %>
-                      <% user = User.find(appointments[i].inviter_user_id) %>
-                      <%= user.organization.name %>
-                    <% end %>
-                  </div>
-                  <div class='bex-agenda-column'>
-                    <% if appointments[i].present? %>
-                      <% if appointments[i].origin_department.present? %>
-                        <%= t("activerecord.attributes.appointment.origin_departments.#{appointments[i].origin_department}") %>
-                      <% elsif appointments[i].inviter_user_id.present? %>
-                        <% user = User.find(appointments[i].inviter_user_id) %>
-                        <%= t("activerecord.attributes.user.user_roles.#{user.role}") %>
-                      <% end %>
-                    <% end %>
-                  </div>
-                  <% if current_user.work_at_bex? || current_user.admin? %>
+              <% agenda.slots_for_date(@selected_day, @appointment_type).each do |slot| %>
+                <% appointments = slot.appointments.active %>
+                <% slot.capacity.times do |i| %>
+                  <div class='bex-agenda-line'>
                     <div class='bex-agenda-small-column'>
-                      <% if appointments[i].present? %>
-                        <%= form_tag appointment_prepare_path(appointments[i]), method: 'put', class: 'bex-agenda-case-prepared-form' do %>
-                          <%= check_box_tag "case-prepared-#{appointments[i].id}",
-                                            true,
-                                            appointments[i].case_prepared,
-                                            class: 'bex-agenda-case-prepared-checkbox',
-                                            onchange: 'this.form.submit()' %>
+                      <% if i == 0 %>
+                        <%= slot.localized_time.to_s(:lettered) %>
+                      <% end %>
+                    </div>
+                    <div class='bex-agenda-column'>
+                      <% unless appointments[i].nil? %>
+                        <%= link_to convict_path(appointments[i]&.convict), class: 'index-control' do %>
+                          <%= appointments[i]&.convict&.last_name&.upcase %>
                         <% end %>
                       <% end %>
                     </div>
-                  <% end %>
-                </div>
+                    <div class='bex-agenda-column'>
+                      <%= appointments[i]&.convict&.first_name %>
+                    </div>
+                    <div class='bex-agenda-column'>
+                      <%= appointments[i]&.prosecutor_number %>
+                    </div>
+                    <div class='bex-agenda-column'>
+                      <% if appointments[i].present? && appointments[i].creating_organization.present? %>
+                        <%= appointments[i].creating_organization.name %>
+                      <% elsif appointments[i].present? && appointments[i].inviter_user_id.present? %>
+                        <% user = User.find(appointments[i].inviter_user_id) %>
+                        <%= user.organization.name %>
+                      <% end %>
+                    </div>
+                    <div class='bex-agenda-column'>
+                      <% if appointments[i].present? %>
+                        <% if appointments[i].origin_department.present? %>
+                          <%= t("activerecord.attributes.appointment.origin_departments.#{appointments[i].origin_department}") %>
+                        <% elsif appointments[i].inviter_user_id.present? %>
+                          <% user = User.find(appointments[i].inviter_user_id) %>
+                          <%= t("activerecord.attributes.user.user_roles.#{user.role}") %>
+                        <% end %>
+                      <% end %>
+                    </div>
+                    <% if current_user.work_at_bex? || current_user.admin? %>
+                      <div class='bex-agenda-small-column'>
+                        <% if appointments[i].present? %>
+                          <%= form_tag appointment_prepare_path(appointments[i]), method: 'put', class: 'bex-agenda-case-prepared-form' do %>
+                            <%= check_box_tag "case-prepared-#{appointments[i].id}",
+                                              true,
+                                              appointments[i].case_prepared,
+                                              class: 'bex-agenda-case-prepared-checkbox',
+                                              onchange: 'this.form.submit()' %>
+                          <% end %>
+                        <% end %>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
               <% end %>
-            <% end %>
+            </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
     <% end %>
-  <% end %>
 </div>

--- a/app/views/bex/agenda_jap.html.erb
+++ b/app/views/bex/agenda_jap.html.erb
@@ -25,12 +25,43 @@
       <div class='bex-date-title-container'>
         <%= t('bex.jap.agendas_title') %>
       </div>
-      <div class='bex-date-select-container'>
+      <div class='bex-filters-container'>
         <%= form_tag agenda_jap_path, method: 'get' do %>
-          <%= select_tag :date, options_for_select(formated_dates_for_select(current_department.tribunal.ten_next_days_with_slots(@appointment_type)), params[:date]),
-                                id: 'jap-appointments-date-select',
-                                class: 'form-select form-text-input jap-date-select',
-                                onchange: 'this.form.submit()' %>
+          <div class="bex-form-input-wrapper">
+            <%= label_tag 'month', 'Mois :' %>
+            <%= select_tag :month, options_for_select(formated_month_for_select(six_next_months), params[:date]),
+                                  id: 'spip-appointments-month-select',
+                                  class: 'form-select form-text-input spip-date-select',
+                                  onchange: 'this.form.submit()' %>
+          </div>
+
+          <div class="bex-form-input-wrapper">
+            <%= label_tag 'day', 'Jour :' %>
+            <%= select_tag :date, options_for_select(formated_days_for_select(@selected_month_dates), params[:date]),
+                                  id: 'spip-appointments-month-select',
+                                  class: 'form-select form-text-input spip-date-select',
+                                  onchange: 'this.form.submit()' %>
+          </div>
+
+
+          <% if @places.count > 0 %>
+            <div class="bex-form-input-wrapper">
+              <%= label_tag 'place_id', 'Lieu :' %>
+              <%= select_tag :place_id, options_from_collection_for_select(@places, 'id', 'name', @place.id), class: 'form-select form-text-input spip-place-select', onchange: 'this.form.submit()' %>
+            </div>
+          <% end %>
+          <% if @agendas.count > 1 %>
+            <div class="bex-form-input-wrapper">
+              <%= label_tag 'agenda_id', 'Agenda :' %>
+              <%= select_tag :agenda_id, options_from_collection_for_select(@agendas, 'id', 'name', @agenda.id), class: 'form-select form-text-input spip-agenda-select', onchange: 'this.form.submit()' %>
+            </div>
+          <% end %>
+
+
+
+
+
+  
         <% end %>
       </div>
     </div>

--- a/app/views/bex/agenda_jap_pdf.html.erb
+++ b/app/views/bex/agenda_jap_pdf.html.erb
@@ -2,11 +2,9 @@
 <h1 class='pdf-bex-title'><%= t('pdf.bex-jap.title') %></h1>
 <div class='bex-agenda-date'><%= date.strftime('%d/%m/%Y') %></div>
 
-<% if @agendas.empty? %>
-  <p class='bex-agenda-spip-no-agenda'><%= t('bex.jap.no_agenda_available') %></p>
-<% else %>
-  <% @agendas.each_with_index do |agenda, index| %>
-    <% unless agenda.slots_for_date(@current_date, @appointment_type).count.zero? %>
+
+  <% @agendas_to_display.each_with_index do |agenda, index| %>
+    <% unless agenda.slots_for_date(@selected_day, @appointment_type).count.zero? %>
       <div class='bex-agenda-container'>
         <div class='bex-agenda-header jap-agenda-header<%= index+1%>'>
           <div class='bex-agenda-header-title'>
@@ -36,7 +34,7 @@
             </div>
           </div>
 
-          <% agenda.slots_for_date(@current_date, @appointment_type).each do |slot| %>
+          <% agenda.slots_for_date(@selected_day, @appointment_type).each do |slot| %>
             <% appointments = slot.appointments.active %>
             <% slot.capacity.times do |i| %>
               <div class='bex-agenda-line'>
@@ -79,4 +77,3 @@
       </div>
     <% end %>
   <% end %>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,9 +94,9 @@ Rails.application.routes.draw do
   get '/stats' => redirect('https://infogram.com/column-stacked-chart-1h7z2l8www5rg6o?live', status: 302), as: :stats
 
   scope controller: :bex do
-    get :agenda_jap
-    get :agenda_spip
-    get :agenda_sap_ddse
+    match :agenda_jap, via: [:get, :post], defaults: { appointment_type: 'Sortie d\'audience SAP', }
+    get :agenda_spip, defaults: { appointment_type: 'Sortie d\'audience SPIP' }
+    get :agenda_sap_ddse, defaults: { appointment_type: 'SAP DDSE' }
   end
 
   scope controller: :home do

--- a/spec/features/bex_spec.rb
+++ b/spec/features/bex_spec.rb
@@ -27,6 +27,9 @@ RSpec.feature 'Bex', type: :feature do
 
       place = create(:place, name: 'Tribunal de Nanterre', organization: @organization)
 
+      create(:place_appointment_type, place: place, appointment_type: apt_type)
+      create(:place_appointment_type, place: place, appointment_type: apt_type2)
+
       agenda1 = create(:agenda, place: place, name: 'Cabinet Bleu')
       agenda2 = create(:agenda, place: place, name: 'Cabinet Rouge')
       agenda3 = create(:agenda, place: place, name: 'Cabinet Jaune')
@@ -54,7 +57,8 @@ RSpec.feature 'Bex', type: :feature do
                                                   starting_time: '12h',
                                                   capacity: 2)
 
-      current_date = slot1.date.strftime('%d/%m/%Y')
+
+      current_date = (I18n.l slot1.date, format: '%A %d').capitalize
 
       create(:appointment, slot: slot1, convict: convict1, prosecutor_number: '203204', inviter_user_id: @bex_user.id)
       create(:appointment, slot: slot2, convict: convict2, prosecutor_number: '205206', inviter_user_id: @bex_user.id)
@@ -63,10 +67,10 @@ RSpec.feature 'Bex', type: :feature do
       create(:appointment, slot: slot4, convict: convict2, prosecutor_number: '205206', inviter_user_id: @bex_user.id)
 
       visit agenda_jap_path
-      select current_date, from: :date
-      page.execute_script("$('#jap-appointments-date-select').trigger('change')")
 
-      expect(page).to have_current_path(agenda_jap_path(date: current_date))
+      select current_date, from: :date
+
+      expect(page).to have_current_path(agenda_jap_path())
 
       agenda_containers = page.all('.bex-agenda-container', minimum: 2)
 

--- a/spec/features/bex_spec.rb
+++ b/spec/features/bex_spec.rb
@@ -57,7 +57,6 @@ RSpec.feature 'Bex', type: :feature do
                                                   starting_time: '12h',
                                                   capacity: 2)
 
-
       current_date = (I18n.l slot1.date, format: '%A %d').capitalize
 
       create(:appointment, slot: slot1, convict: convict1, prosecutor_number: '203204', inviter_user_id: @bex_user.id)
@@ -70,7 +69,7 @@ RSpec.feature 'Bex', type: :feature do
 
       select current_date, from: :date
 
-      expect(page).to have_current_path(agenda_jap_path())
+      expect(page).to have_current_path(agenda_jap_path)
 
       agenda_containers = page.all('.bex-agenda-container', minimum: 2)
 

--- a/spec/features/bex_spec.rb
+++ b/spec/features/bex_spec.rb
@@ -98,6 +98,7 @@ RSpec.feature 'Bex', type: :feature do
       create :areas_convicts_mapping, convict: convict, area: @department
       apt_type = create(:appointment_type, name: "Sortie d'audience SAP")
       place = create(:place, name: 'SPIP 91', organization: @organization)
+      create(:place_appointment_type, place: place, appointment_type: apt_type)
       agenda = create(:agenda, place: place, name: 'Agenda SPIP 91')
 
       slot = create(:slot, :without_validations, agenda: agenda,
@@ -105,12 +106,11 @@ RSpec.feature 'Bex', type: :feature do
                                                  date: Date.today.next_occurring(:tuesday))
 
       appointment = create(:appointment, slot: slot, convict: convict, inviter_user_id: @bex_user.id)
-      current_date = slot.date.strftime('%d/%m/%Y')
+      current_date = (I18n.l slot.date, format: '%A %d').capitalize
 
       visit agenda_jap_path
 
       select current_date, from: :date
-      page.execute_script("$('#jap-appointments-date-select').trigger('change')")
 
       expect(appointment.case_prepared).to eq(false)
 


### PR DESCRIPTION
Relates to https://www.notion.so/monsuivijustice/Modification-de-la-page-sortie-d-audience-JAP-66776999a213405183b9d6ea423a349c

Sortie d'audience page can now be filtered by month, day (only days with open slots are available) and agenda

<img width="1630" alt="Capture d’écran 2022-12-21 à 11 30 31" src="https://user-images.githubusercontent.com/25039335/208883916-83a29a55-5273-4ddd-8e83-7ca95f7e864a.png">

