### PR TITLE
added execute stored procedures job

### DIFF
--- a/app/jobs/execute_stored_procedures_job.rb
+++ b/app/jobs/execute_stored_procedures_job.rb
@@ -1,0 +1,10 @@
+class ExecuteStoredProceduresJob < ApplicationJob
+    def perform
+        @connection = ActiveRecord::Base.connection
+        @connection.exec_query("call update_model_probationnaire()")
+        @connection.exec_query("call update_model_appointments()")
+        @connection.exec_query("call update_model_sms()")
+        ActiveRecord::Base.clear_active_connections!
+    end
+end
+  

--- a/app/jobs/execute_stored_procedures_job.rb
+++ b/app/jobs/execute_stored_procedures_job.rb
@@ -1,10 +1,9 @@
 class ExecuteStoredProceduresJob < ApplicationJob
-    def perform
-        @connection = ActiveRecord::Base.connection
-        @connection.exec_query("call update_model_probationnaire()")
-        @connection.exec_query("call update_model_appointments()")
-        @connection.exec_query("call update_model_sms()")
-        ActiveRecord::Base.clear_active_connections!
-    end
+  def perform
+    @connection = ActiveRecord::Base.connection
+    @connection.exec_query('call update_model_probationnaire()')
+    @connection.exec_query('call update_model_appointments()')
+    @connection.exec_query('call update_model_sms()')
+    ActiveRecord::Base.clear_active_connections!
+  end
 end
-  

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -11,4 +11,9 @@ module Clockwork
   every(1.day, 'slot_creation.job', at: '00:00') { SlotCreationJob.perform_later }
   every(1.day, 'archived_convict_deletion.job', at: '01:00') { ArchivedConvictsDestroyJob.perform_later }
   every(1.day, 'tracking_cleaning.job', at: '02:00') { TrackingCleaningJob.perform_later }
+
+  # Populate dedicted pgsql tables for Metabse. Do this one only on production env
+  if ENV['APP'] == 'mon-suivi-justice-production'
+    every(1.day, 'execute_stored_procedures.job', at: '03:00') { ExecuteStoredProceduresJob.perform_later }
+  end
 end


### PR DESCRIPTION
Relates to https://www.notion.so/monsuivijustice/Cr-er-les-proc-dures-stock-es-sur-msj-prod-pour-metabase-a0f6c85f24424578a95abc53e1c0f7da

These stored procedures are meant to populate `model_probationnaire`, `model_appointments` and `model_sms` tables which are used by MetaBase.