### PR TITLE
override papertrail user method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,6 +52,10 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_time_zone
 
+  def user_for_paper_trail
+    true_user.try(:id)
+  end
+
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private


### PR DESCRIPTION
When admin impersonate regular users, we want to be able to track their actions in papertrail.