### PR TITLE
APPI import should not crash because of syntax errors

### DIFF
--- a/app/controllers/admin/import_convicts_controller.rb
+++ b/app/controllers/admin/import_convicts_controller.rb
@@ -28,22 +28,20 @@ module Admin
       appi_data = []
 
       csv.each_with_index do |row, i|
-        begin
-          next if ['EMPRISONNEMENT', 'AMÉNAGEMENT DE PEINE',
-                  'Placement en détention provisoire'].include?(row['Mesure/Intervention'].split(' (')[0])
+        next if ['EMPRISONNEMENT', 'AMÉNAGEMENT DE PEINE',
+                 'Placement en détention provisoire'].include?(row['Mesure/Intervention'].split(' (')[0])
 
-          convict = {
-            first_name: row['Prénom'],
-            last_name: row['Nom'],
-            date_of_birth: row['Date de naissance'].to_date,
-            no_phone: true,
-            appi_uuid: row['Numéro de dossier'].split('°')[1]
-          }
+        convict = {
+          first_name: row['Prénom'],
+          last_name: row['Nom'],
+          date_of_birth: row['Date de naissance'].to_date,
+          no_phone: true,
+          appi_uuid: row['Numéro de dossier'].split('°')[1]
+        }
 
-          appi_data.push(convict)
-        rescue StandardError => e
-          csv_errors.push("Erreur : #{e.message} sur la ligne #{i}")
-        end
+        appi_data.push(convict)
+      rescue StandardError => e
+        csv_errors.push("Erreur : #{e.message} sur la ligne #{i}")
       end
     rescue StandardError => e
       flash.now[:error] = "Erreur : #{e.message}"

--- a/app/jobs/appi_import_job.rb
+++ b/app/jobs/appi_import_job.rb
@@ -5,7 +5,6 @@ class AppiImportJob < ApplicationJob
   def perform(appi_data, organization, user, csv_errors)
     @import_errors = []
     @import_successes = []
-    csv_errors
 
     process_appi_data(appi_data, organization)
   rescue StandardError => e

--- a/app/jobs/appi_import_job.rb
+++ b/app/jobs/appi_import_job.rb
@@ -2,16 +2,17 @@ class AppiImportJob < ApplicationJob
   require 'csv'
   queue_as :default
 
-  def perform(appi_data, organization, user)
+  def perform(appi_data, organization, user, csv_errors)
     @import_errors = []
     @import_successes = []
+    csv_errors
 
     process_appi_data(appi_data, organization)
   rescue StandardError => e
     @import_errors.push("Erreur : #{e.message}")
   ensure
     AdminMailer.with(user: user, organization: organization, import_errors: @import_errors,
-                     import_successes: @import_successes).appi_import_report.deliver_later
+                     import_successes: @import_successes, csv_errors: csv_errors).appi_import_report.deliver_later
   end
 
   def process_appi_data(appi_data, organization)

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -6,6 +6,7 @@ class AdminMailer < ApplicationMailer
     @organization = params[:organization]
     @import_successes = params[:import_successes]
     @import_errors = params[:import_errors]
+    @csv_errors = params[:csv_errors]
     mail(to: @user.email, subject: "Rapport import APPI #{@organization.name}")
   end
 end

--- a/app/views/admin_mailer/appi_import_report.html.erb
+++ b/app/views/admin_mailer/appi_import_report.html.erb
@@ -6,17 +6,23 @@
   <body>
     <h1>Rapport d'import APPI dans msj pour, <%= @organization.name %></h1>
     <ul>
-        <% if !@import_successes.nil? && @import_successes.any? %>
-        <li><%= @import_successes.length %> ppsmjs ont été créées :</li>
-        <% @import_successes.each do |success| %>
-            <li><%= success %></li>
+          <% if !@csv_errors.nil? && @csv_errors.any? %>
+          <h1><%= @csv_errors.length %> erreurs de syntaxe dans le fichier :</h1>
+          <% @csv_errors.each do |error| %>
+              <li style="color: red"><%= error %></li>
+          <% end %>
         <% end %>
+        <% if !@import_successes.nil? && @import_successes.any? %>
+          <h1><%= @import_successes.length %> ppsmjs ont été créées :</h1>
+          <% @import_successes.each do |success| %>
+              <li><%= success %></li>
+          <% end %>
         <% end %>
         <% if !@import_errors.nil? && @import_errors.any? %>
-        <li><%= @import_errors.length %> ppsmjs n'ont pas pu être créées :</li>
-        <% @import_errors.each do |error| %>
-            <li style="color: red"><%= error %></li>
-        <% end %>
+          <h1><%= @import_errors.length %> ppsmjs n'ont pas pu être créées :</h1>
+          <% @import_errors.each do |error| %>
+              <li style="color: red"><%= error %></li>
+          <% end %>
         <% end %>
     </ul>
   </body>


### PR DESCRIPTION
Les exports APPI contiennent probablement des erreurs de syntaxe. Le script d'import les rescue et les ajoute à la liste d'erreurs envoyée par mail à l'admin.

<img width="726" alt="Capture d’écran 2023-03-28 à 10 18 27" src="https://user-images.githubusercontent.com/25039335/228173896-76aeb491-21ff-4824-9789-3c8743ed14e0.png">
