### PR TITLE
Feature/add antenne when there is one

### DIFF
--- a/app/controllers/admin/seeds_controller.rb
+++ b/app/controllers/admin/seeds_controller.rb
@@ -60,16 +60,30 @@ module Admin
       FROM monsuivijustice_commune c;")
 
       ActiveRecord::Base.connection.execute("
-
         INSERT INTO srj_spips(name, structure_id, updated_at, created_at)
-          SELECT DISTINCT
-            s.name,
-            s.id AS structure_id,
+          SELECT 
+            ms.name, 
+            ms.id AS structure_id, 
             NOW() as updated_at,
             NOW() as created_at
-        FROM monsuivijustice_structure s
-        INNER JOIN monsuivijustice_relation_commune_structure rcs ON rcs.structure_id = s.id
-        WHERE s.name LIKE 'Service%' OR s.name LIKE 'Antenne de%'
+          FROM public.monsuivijustice_commune mc
+          INNER JOIN (
+              SELECT rcs.commune_id, MIN(CASE WHEN s.name LIKE '%Antenne%' THEN s.id ELSE NULL END) AS antenne_structure_id, MIN(CASE WHEN s.name NOT LIKE '%Antenne%' THEN s.id ELSE NULL END) AS other_structure_id
+              FROM public.monsuivijustice_relation_commune_structure rcs
+              INNER JOIN public.monsuivijustice_structure s ON s.id = rcs.structure_id
+              WHERE s.name NOT LIKE '%Tribunal%'
+              GROUP BY rcs.commune_id
+          ) AS structures ON structures.commune_id = mc.id
+          LEFT JOIN public.monsuivijustice_structure ms ON ms.id = COALESCE(structures.antenne_structure_id, structures.other_structure_id)
+          WHERE mc.id NOT IN (
+              SELECT c.id FROM public.monsuivijustice_commune c
+              INNER JOIN public.monsuivijustice_relation_commune_structure rcs ON rcs.commune_id = c.id
+              INNER JOIN public.monsuivijustice_structure s ON s.id = rcs.structure_id
+              WHERE s.name LIKE '%Service%'
+              GROUP BY c.id
+              HAVING count(*) > 2
+          )
+          ORDER BY mc.id
         ;")
 
       ActiveRecord::Base.connection.execute("


### PR DESCRIPTION
La nouvelle requête qui insère dans srj_spips récupère pour chaque commune (En excluant toutes les communes qui sont contenues dans la sous-requête qui sélectionne les communes avec plus de 2 services de type spip (que j'avais envoyé à Yannick)) l'id de service minimum où le nom du service contient "Antenne" et l'id de service minimum où le nom de la structure ne contient pas "Antenne" (tout en excluant les structures où le nom contient "Tribunal"). Après on fait une jointure externe avec monsuivijustice_structure pour obtenir les structures correspondantes pour chaque commune.