### PR TITLE
Only display available slots in agendas

### DIFF
--- a/app/models/agenda.rb
+++ b/app/models/agenda.rb
@@ -32,7 +32,7 @@ class Agenda < ApplicationRecord
   end
 
   def slots_for_date(date, appointment_type)
-    slots.where(date: date, appointment_type: appointment_type)
+    slots.where(date: date, appointment_type: appointment_type, available: true)
          .order(:date, :starting_time)
          .uniq
   end


### PR DESCRIPTION
related to: https://www.notion.so/monsuivijustice/Affichage-dans-l-agenda-de-cr-neaux-sortie-d-audience-SPIP-ferm-s-d9587320a45049db9ebf543849e2d7d0?pvs=4