### PR TITLE
Fix extra fields

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -32,13 +32,13 @@ class AppointmentsController < ApplicationController
 
   def new
     @appointment = Appointment.new
-    @extra_fields = current_user.organization.extra_fields.select(&:appointment_create?)
-    @extra_fields.each { |extra_field| @appointment.appointment_extra_fields.build(extra_field: extra_field) }
     authorize @appointment
 
     return unless params.key?(:convict_id)
 
     @convict = Convict.find(params[:convict_id])
+    @extra_fields = @convict.organizations.tj.first.extra_fields.select(&:appointment_create?)
+    @extra_fields.each { |extra_field| @appointment.appointment_extra_fields.build(extra_field: extra_field) }
   end
 
   def create

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -30,8 +30,8 @@
 
         <div class="d-none" data-appointment-extra-field-display-target="extraFieldsContainer">
           <%= f.fields_for :appointment_extra_fields do |extra_field_form|%>
-            <%= extra_field_form.input :extra_field_id, as: :hidden, input_html: {"data-appointment-extra-field-display-target": "extraFieldInputs"}, disabled: true %>
-            <%= extra_field_form.input :value, label: @extra_fields[extra_field_form.index]&.name, input_html: { :type => @extra_fields[extra_field_form.index]&.data_type, "data-appointment-extra-field-display-target": "extraFieldInputs"}, disabled: true %>
+            <%= extra_field_form.input :extra_field_id, as: :hidden, input_html: {"data-appointment-extra-field-display-target": "extraFieldInputs", "data-apt-type": @extra_fields[extra_field_form.index].appointment_type_ids }, disabled: true %>
+            <%= extra_field_form.input :value, label: @extra_fields[extra_field_form.index]&.name, input_html: { :type => @extra_fields[extra_field_form.index]&.data_type, "data-appointment-extra-field-display-target": "extraFieldInputs", "data-apt-type": @extra_fields[extra_field_form.index].appointment_type_ids}, disabled: true %>
           <% end%>
         </div>
       </div>


### PR DESCRIPTION
Fix extra fields for inter ressort and intra ressort
warning: now extra fields only work if a convict is already selected when creating a new appointment (`/appointment/new?convict_id=...`