### PR TITLE
forbid local admin tj from unassigning cpip

### DIFF
--- a/app/policies/convict_policy.rb
+++ b/app/policies/convict_policy.rb
@@ -45,7 +45,7 @@ class ConvictPolicy < ApplicationPolicy
   end
 
   def unassign?
-    (user.cpip? && record.user == user) || user.dpip? || user.local_admin?
+    (user.cpip? && record.user == user) || user.dpip? || user.local_admin_spip?
   end
 
   def destroy?


### PR DESCRIPTION
related to https://www.notion.so/monsuivijustice/Les-admins-locaux-TJ-ne-doivent-pas-pouvoir-d-sattribuer-un-CPIP-d-une-PPSMJ-2d1cbdcc3605422d8795583f3ed0873b?pvs=4