### PR TITLE
changed default sender for both devise and app mailers

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'contact@mon-suivi-justice.beta.gouv.fr'
+  default from: 'support@mon-suivi-justice.beta.gouv.fr'
   layout 'mailer'
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'contact@mon-suivi-justice.beta.gouv.fr'
+  config.mailer_sender = 'support@mon-suivi-justice.beta.gouv.fr'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Relates to https://www.notion.so/monsuivijustice/Changer-le-mail-d-faut-pour-l-envoie-des-emails-de-l-application-SMS-a6517c49a8964d019d63765acefb0f26?pvs=4