### PR TITLE
removed deploy staging instruction from cli script

### DIFF
--- a/cli
+++ b/cli
@@ -38,16 +38,6 @@ class CLI < Thor
     end
   end
 
-  desc 'deploy_staging', 'deploy staging from develop'
-  def deploy_staging
-    run('git push scalingo develop:master')
-    run('scalingo -a mon-suivi-justice-staging run rails db:migrate')
-
-    say
-    say 'Staging deployed'
-    say
-  end
-
   desc 'console_staging', 'launch MSJ staging rails console'
   def console_staging
     run('scalingo -a mon-suivi-justice-staging run rails console')


### PR DESCRIPTION
relates to https://www.notion.so/monsuivijustice/Migrations-pas-ex-cut-es-lors-des-d-ploiements-en-production-6f24b94045d043efba9bc5234352baa7?pvs=4

Now using automatic deployments (Scalingo feature).
<img width="1265" alt="Capture d’écran 2023-05-30 à 10 56 50" src="https://github.com/betagouv/mon-suivi-justice/assets/25039335/2fce4947-80a0-4e4a-82ae-06537e1b6e2e">

