### PR TITLE
fixed env var error in for stored procedures job

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -13,7 +13,7 @@ module Clockwork
   every(1.day, 'tracking_cleaning.job', at: '02:00') { TrackingCleaningJob.perform_later }
 
   # Populate dedicted pgsql tables for Metabse. Do this one only on production env
-  if ENV['APP'] == 'mon-suivi-justice-production'
+  if ENV['APP'] == 'mon-suivi-justice-prod'
     every(1.day, 'execute_stored_procedures.job', at: '03:00') { ExecuteStoredProceduresJob.perform_later }
   end
 end


### PR DESCRIPTION
Relates to https://www.notion.so/monsuivijustice/Refaire-fonctionner-les-proc-dures-Postgres-alimentant-nos-models-Metabase-f8f1dd4ceae94cb1a2bd2eecd4ddb790?pvs=4

L'exécution des procédures stockées peuplant les models destinés à Metabase n'était pas déclenchée la nuit comme prévu. 