### PR TITLE
Feature/improve inter ressort flashes

### DIFF
--- a/app/assets/stylesheets/convicts.scss
+++ b/app/assets/stylesheets/convicts.scss
@@ -254,14 +254,6 @@
   margin-bottom: 5px;
 }
 
-.city-selector {
-  margin-bottom: 20px;
-}
-
-#city-organizations {
-  color: red
-}
-
 body.autocomplete #modal-autocomplete {
   display: block;
   z-index: 1;

--- a/app/controllers/appointments_bookings_controller.rb
+++ b/app/controllers/appointments_bookings_controller.rb
@@ -19,10 +19,6 @@ class AppointmentsBookingsController < ApplicationController
     @convict = params[:convict_id].present? ? Convict.find(params[:convict_id]) : nil
 
     return if @convict.city_id
-
-    flash.now[:warning] =
-      "La prise de RDV ne sera possible que dans votre ressort: <a href='/convicts/#{@convict.id}/edit'>
-      Ajouter une commune à #{@convict.full_name}</a>".html_safe
   end
 
   def load_agendas

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,4 +1,6 @@
 class AppointmentsController < ApplicationController
+  include InterRessortFlashes
+
   before_action :authenticate_user!
 
   def index
@@ -38,7 +40,7 @@ class AppointmentsController < ApplicationController
 
     @convict = Convict.find(params[:convict_id])
 
-    set_warning_flash_no_city if current_user.can_use_inter_ressort? && !@convict.city_id
+    set_inter_ressort_flashes if current_user.can_use_inter_ressort?
 
     initialize_extra_fields
   end

--- a/app/controllers/concerns/inter_ressort_flashes.rb
+++ b/app/controllers/concerns/inter_ressort_flashes.rb
@@ -1,0 +1,12 @@
+module InterRessortFlashes
+  extend ActiveSupport::Concern
+
+  def set_inter_ressort_flashes
+    link_to_edit = "<a href='/convicts/#{@convict.id}/edit'>en cliquant ici</a>"
+
+    flash.now[:warning] =
+      "#{I18n.t('convicts.set_inter_ressort_flashes.available_services')}
+         #{@convict.organizations.pluck(:name).join(', ')}.
+          #{I18n.t('convicts.set_inter_ressort_flashes.how_to_add_services')} #{link_to_edit}".html_safe
+  end
+end

--- a/app/controllers/concerns/inter_ressort_flashes.rb
+++ b/app/controllers/concerns/inter_ressort_flashes.rb
@@ -3,10 +3,17 @@ module InterRessortFlashes
 
   def set_inter_ressort_flashes
     link_to_edit = "<a href='/convicts/#{@convict.id}/edit'>en cliquant ici</a>"
+    change_city = I18n.t('convicts.set_inter_ressort_flashes.change_city')
+    add_city = I18n.t('convicts.set_inter_ressort_flashes.add_city')
+    set_city = @convict.city_id ? change_city : add_city
 
-    flash.now[:warning] =
-      "#{I18n.t('convicts.set_inter_ressort_flashes.available_services')}
-         #{@convict.organizations.pluck(:name).join(', ')}.
-          #{I18n.t('convicts.set_inter_ressort_flashes.how_to_add_services')} #{link_to_edit}".html_safe
+    available_organizations = I18n.t('convicts.set_inter_ressort_flashes.available_organizations')
+    organizations_list = @convict.organizations.pluck(:name).join(', ')
+    how_to_add_organizations = I18n.t('convicts.set_inter_ressort_flashes.how_to_add_organizations', msg: set_city)
+
+    warning_message = "#{available_organizations} #{organizations_list}.
+      #{how_to_add_organizations} #{link_to_edit}".html_safe
+
+    flash.now[:warning] = warning_message
   end
 end

--- a/app/controllers/convicts_controller.rb
+++ b/app/controllers/convicts_controller.rb
@@ -1,4 +1,6 @@
 class ConvictsController < ApplicationController
+  include InterRessortFlashes
+
   before_action :authenticate_user!
 
   def show
@@ -6,7 +8,7 @@ class ConvictsController < ApplicationController
     @history_items = HistoryItem.where(convict: @convict, category: %w[appointment convict])
                                 .order(created_at: :desc)
 
-    set_inter_ressort_warnings if current_user.can_use_inter_ressort?
+    set_inter_ressort_flashes if current_user.can_use_inter_ressort?
 
     authorize @convict
   end
@@ -41,9 +43,6 @@ class ConvictsController < ApplicationController
 
   def edit
     @convict = policy_scope(Convict).find(params[:id])
-
-    set_inter_ressort_warnings if current_user.can_use_inter_ressort?
-
     authorize @convict
   end
 
@@ -177,19 +176,6 @@ class ConvictsController < ApplicationController
 
   def force_duplication?
     ActiveRecord::Type::Boolean.new.deserialize(params.dig(:convict, :force_duplication))
-  end
-
-  def set_inter_ressort_warnings
-    link_to_edit = "<a href='/convicts/#{@convict.id}/edit'>en cliquant ici</a>"
-
-    flash.now[:warning] =
-      "#{@convict.ir_available_services_message}
-        #{I18n.t('convicts.set_inter_ressort_warnings.how_to_add_services')} #{if action_name == 'show'
-                                                                                 link_to_edit
-                                                                               else
-                                                                                 '.'
-                                                                               end
-                                                                             }".html_safe
   end
 
   def bex_user_and_invalid_convict?

--- a/app/controllers/convicts_controller.rb
+++ b/app/controllers/convicts_controller.rb
@@ -6,7 +6,7 @@ class ConvictsController < ApplicationController
     @history_items = HistoryItem.where(convict: @convict, category: %w[appointment convict])
                                 .order(created_at: :desc)
 
-    set_warning_flash_no_city if current_user.can_use_inter_ressort? && !@convict.city_id
+    set_inter_ressort_warnings if current_user.can_use_inter_ressort?
 
     authorize @convict
   end
@@ -42,11 +42,7 @@ class ConvictsController < ApplicationController
   def edit
     @convict = policy_scope(Convict).find(params[:id])
 
-    if current_user.can_use_inter_ressort? && !@convict.city_id
-      flash.now[:warning] =
-        '<strong>ATTENTION. Aucune commune renseignée.</strong> La prise de RDV ne sera possible que dans votre ressort:
-          Utilisez le champ commune ci-dessous pour renseigner une commune'.html_safe
-    end
+    set_inter_ressort_warnings if current_user.can_use_inter_ressort?
 
     authorize @convict
   end
@@ -183,11 +179,17 @@ class ConvictsController < ApplicationController
     ActiveRecord::Type::Boolean.new.deserialize(params.dig(:convict, :force_duplication))
   end
 
-  def set_warning_flash_no_city
+  def set_inter_ressort_warnings
+    link_to_edit = "<a href='/convicts/#{@convict.id}/edit'>en cliquant ici</a>"
+
     flash.now[:warning] =
-      "<strong>ATTENTION. Aucune commune renseignée.</strong>
-     La prise de RDV ne sera possible que dans votre ressort:
-      <a href='/convicts/#{@convict.id}/edit'>Ajouter une commune à #{@convict.full_name}</a>".html_safe
+      "#{@convict.ir_available_services_message}
+        #{I18n.t('convicts.set_inter_ressort_warnings.how_to_add_services')} #{if action_name == 'show'
+                                                                                 link_to_edit
+                                                                               else
+                                                                                 '.'
+                                                                               end
+                                                                             }".html_safe
   end
 
   def bex_user_and_invalid_convict?

--- a/app/helpers/convicts_helper.rb
+++ b/app/helpers/convicts_helper.rb
@@ -14,4 +14,8 @@ module ConvictsHelper
   def cpip_for_select(organization)
     User.in_organization(organization).where(role: %w[cpip dpip])
   end
+
+  def ir_available_services(convict)
+    convict.organizations.pluck(:name).join(', ')
+  end
 end

--- a/app/javascript/controllers/search_cities_controller.js
+++ b/app/javascript/controllers/search_cities_controller.js
@@ -1,59 +1,57 @@
-import Rails from "@rails/ujs";
 import { ApplicationController, useDebounce } from 'stimulus-use'
 
 export default class extends ApplicationController {
-    static targets = ["results", "query"]
-    static debounces = ['search']
+  static targets = ["results", "query"]
+  static debounces = ['search']
 
-    connect() {
-        console.log('search cities controller connected')
-        useDebounce(this, { wait: 500 })
+  connect() {
+    useDebounce(this, { wait: 500 })
+  }
+
+  get query() {
+    return this.queryTarget.value
+  }
+
+  search() {
+    if (this.query.length < 3) {
+        return
+      }
+
+    if (this.query == this.previousQuery) {
+        return
     }
+    this.previousQuery = this.query
 
-    get query() {
-        return this.queryTarget.value
+    this.abortPreviousFetchRequest()
+
+    this.abortController = new AbortController()
+    fetch('/cities/search?q=' + this.query, { signal: this.abortController.signal })
+        .then(response => response.text())
+        .then(html => {
+            this.handleResults(html)
+        })
+        .catch((e) => { 
+            console.log(e)
+        })
+  }
+  
+  reset() {
+    this.resultsTarget.innerHTML = ""
+    this.queryTarget.value = ""
+    this.previousQuery = null
+  }
+
+  abortPreviousFetchRequest() {
+    if (this.abortController) {
+        this.abortController.abort()
     }
+  }
 
-    search() {
-        if (this.query.length < 3) {
-            return
-          }
+  handleResults(data) {
+    this.resultsTarget.innerHTML = data
+  }
 
-        if (this.query == this.previousQuery) {
-            return
-        }
-        this.previousQuery = this.query
-
-        this.abortPreviousFetchRequest()
-
-        this.abortController = new AbortController()
-        fetch('/cities/search?q=' + this.query, { signal: this.abortController.signal })
-            .then(response => response.text())
-            .then(html => {
-                this.handleResults(html)
-            })
-            .catch((e) => { 
-                console.log(e)
-            })
-    }
-    
-    reset() {
-        this.resultsTarget.innerHTML = ""
-        this.queryTarget.value = ""
-        this.previousQuery = null
-    }
-
-    abortPreviousFetchRequest() {
-        if (this.abortController) {
-            this.abortController.abort()
-        }
-    }
-
-    handleResults(data) {
-        this.resultsTarget.innerHTML = data
-    }
-
-    clearResults() {
-        this.resultsTarget.innerHTML = ""
-    }
+  clearResults() {
+    this.resultsTarget.innerHTML = ""
+  }
 }

--- a/app/javascript/controllers/search_cities_results_controller.js
+++ b/app/javascript/controllers/search_cities_results_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
     })
     .then(data => {
       this.organizationsInfoTarget.className = "fr-alert fr-alert--info fr-alert--sm fr-mb-3w"
-      const convictCurrentOrganizations = `les services actuels de la ppsmj:<strong> ${this.irCitiesValue}</strong>.`
+      const convictCurrentOrganizations = `les services actuels de la PPSMJ:<strong> ${this.irCitiesValue}</strong>.`
 
       if (data.length > 0) {        
         const servicesList = data.map((orga) => orga.name).join(', ')
@@ -39,7 +39,7 @@ export default class extends Controller {
         Vous pourrez poursuivre la prise de rendez-vous dans ces services${ this.actionNameValue == "new" ? '.' : ' et dans ' + convictCurrentOrganizations}`;
       } else {
           this.organizationsInfoTarget.hidden = false;
-          this.organizationsInfoTarget.getElementsByTagName('p')[0].innerHTML = `Mon Suivi Justice n\' est déployé dans aucun ressort de cette commune. <br />
+          this.organizationsInfoTarget.getElementsByTagName('p')[0].innerHTML = `Mon Suivi Justice n\' est déployé dans aucun service de cette commune. <br />
           Vous pourrez poursuivre la prise de rendez-vous uniquement dans ${this.actionNameValue == "new" ? 'votre ressort' : convictCurrentOrganizations }`
       } 
     })

--- a/app/javascript/controllers/search_cities_results_controller.js
+++ b/app/javascript/controllers/search_cities_results_controller.js
@@ -4,8 +4,9 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["selectedCity", "organizationsInfo", "hiddenField"]
 
-  connect() {
-    console.log('city selector controller connected')
+  static values = {
+    irCities: String,
+    actionName: String
   }
 
   selectCity(event) {
@@ -28,18 +29,22 @@ export default class extends Controller {
       return response.json();
     })
     .then(data => {
-      if (data.length === 1) {
+      this.organizationsInfoTarget.className = "fr-alert fr-alert--info fr-alert--sm fr-mb-3w"
+      const convictCurrentOrganizations = `les services actuels de la ppsmj:<strong> ${this.irCitiesValue}</strong>.`
+
+      if (data.length > 0) {        
+        const servicesList = data.map((orga) => orga.name).join(', ')
         this.organizationsInfoTarget.hidden = false;
-        this.organizationsInfoTarget.getElementsByTagName('p')[0].innerHTML = `Attention Mon suivi Justice n’est déployé que pour le ${data[0].name}. Vous ne pourrez poursuivre la prise de rendez-vous que pour ce service et votre ressort`;
-    } else if (data.length === 0) {
-        this.organizationsInfoTarget.hidden = false;
-        this.organizationsInfoTarget.getElementsByTagName('p')[0].innerHTML = 'Attention, Mon Suivi Justice n\' est déployé dans aucun ressort de cette commune. Vous ne pourrez poursuivre la prise de rendez-vous que pour votre ressort';
-    } else {
-        this.organizationsInfoTarget.hidden = true;
-    }
+        this.organizationsInfoTarget.getElementsByTagName('p')[0].innerHTML = `Mon suivi Justice est déployé dans les services suivants pour cette commune: <strong>${servicesList}.</strong> <br /> 
+        Vous pourrez poursuivre la prise de rendez-vous dans ces services${ this.actionNameValue == "new" ? '.' : ' et dans ' + convictCurrentOrganizations}`;
+      } else {
+          this.organizationsInfoTarget.hidden = false;
+          this.organizationsInfoTarget.getElementsByTagName('p')[0].innerHTML = `Mon Suivi Justice n\' est déployé dans aucun ressort de cette commune. <br />
+          Vous pourrez poursuivre la prise de rendez-vous uniquement dans ${this.actionNameValue == "new" ? 'votre ressort' : convictCurrentOrganizations }`
+      } 
     })
     .catch(error => {
-      console.error("There was a problem with the fetch operation:", error);
+      alert("Il y a eu un problème lors de la récupération des services. Contactez support@mon-suivi-justice.beta.gouv.fr:", error);
     });
 
   }

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -213,4 +213,8 @@ class Convict < ApplicationRecord
 
     duplicates
   end
+
+  def ir_available_services_message
+    "#{I18n.t('convicts.set_inter_ressort_warnings.available_services')} #{organizations.pluck(:name).join(', ')}."
+  end
 end

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -213,8 +213,4 @@ class Convict < ApplicationRecord
 
     duplicates
   end
-
-  def ir_available_services_message
-    "#{I18n.t('convicts.set_inter_ressort_warnings.available_services')} #{organizations.pluck(:name).join(', ')}."
-  end
 end

--- a/app/views/convicts/edit.html.erb
+++ b/app/views/convicts/edit.html.erb
@@ -104,4 +104,3 @@
     <% end %>
   </div>
 </div>
-<%= javascript_pack_tag 'convict_new' %>

--- a/app/views/convicts/new.html.erb
+++ b/app/views/convicts/new.html.erb
@@ -184,4 +184,3 @@
     <% end %>
   </div>
 </div>
-<%= javascript_pack_tag 'convict_new' %>

--- a/app/views/shared/_city_selector.html.erb
+++ b/app/views/shared/_city_selector.html.erb
@@ -1,6 +1,5 @@
-<% city_organizations = @convict.city&.organizations&.count %>
 <% invalid = @convict.errors.include?(:base) %>
-<div data-controller="search-cities search-cities-results" data-action="search-cities-results:citySelected->search-cities#clearResults">
+<div data-controller="search-cities search-cities-results" data-action="search-cities-results:citySelected->search-cities#clearResults" data-search-cities-results-ir-cities-value="<%= ir_available_services(@convict) %>" data-search-cities-results-action-name-value="<%= action_name %>">
   <div class="fr-input-group">
     <label class="fr-label" for="convict_city_id"><%= t('activerecord.attributes.convict.city_id')%></label>
     <input class="fr-input" type="search" placeholder="<%= 'Changer de commune' if @convict.city %>" name="convict[city_id]" id="convict_city_id" data-search-cities-target="query" data-action="input->search-cities#search">
@@ -13,16 +12,11 @@
   <div id="search_results" data-search-cities-target="results"></div>
   <p data-search-cities-results-target="selectedCity">
     <% if @convict.city %>
-      <strong>Commune sélectionnée : </strong><%= @convict.city.name %>
+      <strong>Commune <%= action_name == 'new' ? 'sélectionnée' : 'actuelle' %>  : </strong><%= @convict.city.name %>
     <% end %>
   </p>
-  <div class="fr-alert fr-alert--error fr-alert--sm fr-mb-3w" data-search-cities-results-target="organizationsInfo" <%= 'hidden' if !(city_organizations === 1 || city_organizations === 0) %> >
+  <div data-search-cities-results-target="organizationsInfo">
     <p>
-      <% if city_organizations === 1 %>
-        Attention Mon suivi Justice n’est déployé que pour le <%= @convict.city&.organizations.first.name %>. Vous ne pourrez poursuivre la prise de rendez-vous que pour ce service et votre ressort
-      <% elsif city_organizations === 0 %>
-        Attention, Mon Suivi Justice n' est déployé dans aucun ressort de cette commune. Vous ne pourrez poursuivre la prise de rendez-vous que pour votre ressort
-      <% end %>
     </p>
   </div>
   <input autocomplete="off" type="hidden" value="<%= @convict.city&.id %>" data-search-cities-results-target="hiddenField" name="convict[city_id]">

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -55,7 +55,7 @@ fr:
       notice: "La PPSMJ vous a bien été attribuée."
     unassign:
       notice: "La PPSMJ a été réattribuée au service"
-    set_inter_ressort_warnings:
+    set_inter_ressort_flashes:
       convict_no_cities: "La PPSMJ n'a pas de commune."
       available_services: "Rendez-vous possibles dans les services suivants:"
       how_to_add_services: "Pour prendre rendez-vous dans un autre service, ajoutez une commune à la PPSMJ ou modifiez la commune existante"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -57,9 +57,11 @@ fr:
       notice: "La PPSMJ a été réattribuée au service"
     set_inter_ressort_flashes:
       convict_no_cities: "La PPSMJ n'a pas de commune."
-      available_services: "Rendez-vous possibles dans les services suivants:"
-      how_to_add_services: "Pour prendre rendez-vous dans un autre service, ajoutez une commune à la PPSMJ ou modifiez la commune existante"
+      available_organizations: "Rendez-vous possibles dans les services suivants:"
+      how_to_add_organizations: "Pour prendre rendez-vous dans un autre service, %{msg}"
       convict_has_city: "La PPSMJ est liée à la commune %{city_name}."
+      add_city: "ajoutez une commune à la PPSMJ"
+      change_city: "modifiez la commune de la PPSMJ"
 
   activerecord:
     models:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -55,6 +55,11 @@ fr:
       notice: "La PPSMJ vous a bien été attribuée."
     unassign:
       notice: "La PPSMJ a été réattribuée au service"
+    set_inter_ressort_warnings:
+      convict_no_cities: "La PPSMJ n'a pas de commune."
+      available_services: "Rendez-vous possibles dans les services suivants:"
+      how_to_add_services: "Pour prendre rendez-vous dans un autre service, ajoutez une commune à la PPSMJ ou modifiez la commune existante"
+      convict_has_city: "La PPSMJ est liée à la commune %{city_name}."
 
   activerecord:
     models:

--- a/spec/features/convicts_spec.rb
+++ b/spec/features/convicts_spec.rb
@@ -235,6 +235,8 @@ RSpec.feature 'Convicts', type: :feature do
       convict = create(:convict, last_name: 'Expresso', date_of_birth: '01/01/1980',
                                  organizations: [@user.organization])
       cpip = create(:user, first_name: 'Rémy', last_name: 'MAU', role: 'cpip', organization: @user.organization)
+
+      
       visit edit_convict_path(convict)
 
       find('#convict_last_name').set('').set('Ristretto')
@@ -296,6 +298,38 @@ RSpec.feature 'Convicts', type: :feature do
                  'Ancien numéro : 06 06 06 06 06.'
 
       expect(page).to have_content(expected)
+    end
+
+    it 'displays proper alerts and update convicts organizations correctly when city is updated', logged_in_as: 'bex', js: true do
+      @user.organization.use_inter_ressort = true
+
+      spip = create(:organization, organization_type: 'spip')
+      tj = create(:organization, organization_type: 'tj')
+
+      convict = create(:convict, phone: nil, no_phone: true, organizations: [spip, tj])
+
+      spip2 = create(:organization, organization_type: 'spip')
+      tj2 = create(:organization, organization_type: 'tj')
+      srj_tj = create(:srj_tj, organization: tj2)
+      srj_spip = create(:srj_spip, organization: spip2)
+
+      create(:city, srj_tj: srj_tj, srj_spip: srj_spip)
+
+      visit edit_convict_path(convict)
+
+      find('#convict_city_id').set('Melun')
+
+      page.has_content?('77000 Melun (France)')
+      find('a', text: '77000 Melun (France)').click
+
+      orgs_info_div = page.find("div[data-search-cities-results-target='organizationsInfo']")
+
+      expect(orgs_info_div).to have_content("Mon suivi Justice est déployé dans les services suivants pour cette commune: #{tj2.name}, #{spip2.name}")
+      expect(orgs_info_div).to have_content("les services actuels de la PPSMJ: #{spip.name}, #{tj.name}")
+
+      click_button 'Enregistrer'
+
+      expect(Convict.last.organizations).to match_array([spip, tj, spip2, tj2])
     end
   end
 

--- a/spec/features/convicts_spec.rb
+++ b/spec/features/convicts_spec.rb
@@ -133,6 +133,10 @@ RSpec.feature 'Convicts', type: :feature do
       page.has_content?('77000 Melun (France)')
 
       find('a', text: '77000 Melun (France)').click
+
+      orgs_info_div = page.find("div[data-search-cities-results-target='organizationsInfo']")
+      expect(orgs_info_div).to have_content("#{tj.name}, #{spip.name}")
+
       find(:css, '#convict-no-phone-checkbox').click
 
       expect { click_button 'submit-no-appointment' }.to change { Convict.count }.by(1)

--- a/spec/features/convicts_spec.rb
+++ b/spec/features/convicts_spec.rb
@@ -236,7 +236,6 @@ RSpec.feature 'Convicts', type: :feature do
                                  organizations: [@user.organization])
       cpip = create(:user, first_name: 'Rémy', last_name: 'MAU', role: 'cpip', organization: @user.organization)
 
-      
       visit edit_convict_path(convict)
 
       find('#convict_last_name').set('').set('Ristretto')
@@ -300,7 +299,8 @@ RSpec.feature 'Convicts', type: :feature do
       expect(page).to have_content(expected)
     end
 
-    it 'displays proper alerts and update convicts organizations correctly when city is updated', logged_in_as: 'bex', js: true do
+    it 'displays proper alerts and update convicts organizations correctly when city is updated', logged_in_as: 'bex',
+                                                                                                  js: true do
       @user.organization.use_inter_ressort = true
 
       spip = create(:organization, organization_type: 'spip')
@@ -324,7 +324,7 @@ RSpec.feature 'Convicts', type: :feature do
 
       orgs_info_div = page.find("div[data-search-cities-results-target='organizationsInfo']")
 
-      expect(orgs_info_div).to have_content("Mon suivi Justice est déployé dans les services suivants pour cette commune: #{tj2.name}, #{spip2.name}")
+      expect(orgs_info_div).to have_content("pour cette commune: #{tj2.name}, #{spip2.name}")
       expect(orgs_info_div).to have_content("les services actuels de la PPSMJ: #{spip.name}, #{tj.name}")
 
       click_button 'Enregistrer'


### PR DESCRIPTION
Relates to : https://www.notion.so/monsuivijustice/Clarifier-les-messages-d-information-lorsqu-un-agent-prend-un-RDV-en-inter-ressort-44529e5a24f14ad6b6b7337f11a72d1c?pvs=4

<img width="1602" alt="Capture d’écran 2023-06-02 à 16 46 05" src="https://github.com/betagouv/mon-suivi-justice/assets/25039335/0a7b74d9-92ac-4bcd-87fe-7225ca11048f">
<img width="822" alt="Capture d’écran 2023-06-02 à 16 46 19" src="https://github.com/betagouv/mon-suivi-justice/assets/25039335/0216341d-8c70-4def-899c-04f4f6cc847d">
<img width="847" alt="Capture d’écran 2023-06-02 à 16 46 28" src="https://github.com/betagouv/mon-suivi-justice/assets/25039335/95ff8fd7-ac36-4d13-bea3-025eae973228">
