### PR TITLE
fixed typo in home stats widget

### DIFF
--- a/app/views/home/_home_stats.html.erb
+++ b/app/views/home/_home_stats.html.erb
@@ -35,7 +35,7 @@
 
         <div class='home-stats-appointment-states'>
           <div class='stat-card-container'>
-            <p class='home-stat-percentage'><b><%= data[:fulfiled_percentage] %>%</b> <%= t('home.stats_fulfiled') %></p>
+            <p class='home-stat-percentage'><b><%= data[:fulfilled_percentage] %>%</b> <%= t('home.stats_fulfiled') %></p>
           </div>
 
           <div class='stat-card-container'>
@@ -76,7 +76,7 @@
 
         <div class='home-stats-appointment-states'>
           <div class='stat-card-container'>
-            <p class='home-stat-percentage'><b><%= data[:fulfiled_percentage] %>%</b> <%= t('home.stats_fulfiled') %></p>
+            <p class='home-stat-percentage'><b><%= data[:fulfilled_percentage] %>%</b> <%= t('home.stats_fulfiled') %></p>
           </div>
 
           <div class='stat-card-container'>


### PR DESCRIPTION
"% de présence" was displaying nothing.

<img width="619" alt="Capture d’écran 2023-06-13 à 10 20 38" src="https://github.com/betagouv/mon-suivi-justice/assets/25039335/f444ccbf-4558-40b8-8273-e770a60e48be">
