### PR TITLE
removed whitelisted phones feature

### DIFF
--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -5,11 +5,6 @@ class Convict < ApplicationRecord
 
   has_paper_trail
 
-  WHITELISTED_PHONES = %w[+33659763117 +33683481555 +33682356466 +33603371085
-                          +33687934479 +33674426177 +33616430756 +33613254126
-                          +33674212998 +33607886138 +33666228742 +33631384053
-                          +33767280303].freeze
-
   DOB_UNIQUENESS_MESSAGE = I18n.t('activerecord.errors.models.convict.attributes.dob.taken')
 
   has_many :convicts_organizations_mappings
@@ -127,10 +122,6 @@ class Convict < ApplicationRecord
     errors.add :phone, I18n.t('activerecord.errors.models.convict.attributes.phone.mobile')
   end
 
-  def phone_whitelisted?
-    WHITELISTED_PHONES.include?(phone)
-  end
-
   def invitable_to_convict_interface?
     phone.present? && invitation_to_convict_interface_count < 2 &&
       timestamp_convict_interface_creation.nil?
@@ -149,7 +140,7 @@ class Convict < ApplicationRecord
   end
 
   def phone_uniqueness
-    return if refused_phone? || no_phone? || phone_whitelisted?
+    return if refused_phone? || no_phone?
 
     return if Convict.where(phone: phone).where.not(id: id).empty?
 

--- a/spec/models/convict_spec.rb
+++ b/spec/models/convict_spec.rb
@@ -49,11 +49,6 @@ RSpec.describe Convict, type: :model do
 
       expect(build(:convict, phone: '0612458744')).not_to be_valid
     end
-
-    it 'accepts a phone already existing in the whitelist' do
-      create(:convict, phone: '0659763117')
-      expect(build(:convict, phone: '0659763117')).to be_valid
-    end
   end
 
   describe 'under_hand_of' do

--- a/spec/policies/convict_invitation_policy_spec.rb
+++ b/spec/policies/convict_invitation_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ConvictInvitationPolicy do
   subject { ConvictInvitationPolicy.new(user, convict) }
 
-  context 'for an admin not whitelisted' do
+  context 'for an admin' do
     let(:user) { build(:user, role: 'admin') }
     let(:convict) { build(:convict) }
 
@@ -17,7 +17,7 @@ describe ConvictInvitationPolicy do
     it { is_expected.to permit_action(:create) }
   end
 
-  context 'for an local_admin not whitelisted' do
+  context 'for a local_admin' do
     let(:user) { build(:user, role: 'local_admin') }
     let(:convict) { build(:convict) }
 


### PR DESCRIPTION
Relates to https://www.notion.so/monsuivijustice/Les-num-ros-de-t-l-phone-de-l-quipe-sont-en-clair-dans-le-repo-c7348c1926a14339af63b1d42c123164?pvs=4

On supprime totalement la fonctionnalité des WHITELISTED_PHONES