### PR TITLE
check duplicates now uses normalize

### DIFF
--- a/app/helpers/convicts_helper.rb
+++ b/app/helpers/convicts_helper.rb
@@ -18,4 +18,8 @@ module ConvictsHelper
   def ir_available_services(convict)
     convict.organizations.pluck(:name).join(', ')
   end
+
+  def link_to_convict_show(convict)
+    link_to 'Voir la PPSMJ', convict_path(convict)
+  end
 end

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -205,8 +205,10 @@ class Convict < ApplicationRecord
 
   def find_duplicates
     name_conditions = 'lower(first_name) = ? AND lower(last_name) = ?'
+    normalized_phone = PhonyRails.normalize_number(phone, country_code: 'FR')
+
     duplicates = Convict.kept.where(name_conditions, first_name.downcase, last_name.downcase)
-                        .where('phone = ? OR (date_of_birth = ? AND phone IS NOT NULL)', phone, date_of_birth)
+                        .where('phone = ? OR (date_of_birth = ? AND phone IS NOT NULL)', normalized_phone, date_of_birth)
                         .where.not(id: id)
 
     duplicates = duplicates.where(appi_uuid: nil) if appi_uuid.present?


### PR DESCRIPTION
Relates to https://www.notion.so/monsuivijustice/La-m-thode-check_duplicates-des-convicts-cherche-aussi-parmi-les-PPSMJ-archiv-es-693e9eaae0cc420f8d37907191cfb52b?pvs=4