### PR TITLE
Fix display date on bex agenda

### DIFF
--- a/app/controllers/bex_controller.rb
+++ b/app/controllers/bex_controller.rb
@@ -93,9 +93,7 @@ class BexController < ApplicationController
   def days_with_slots(appointment_type, month)
     Slot.future
         .in_organization(current_organization)
-        .where(appointment_type: appointment_type, date: month.to_date.all_month.to_a)
-        .joins('LEFT JOIN appointments ON appointments.slot_id = slots.id')
-        .where('slots.available = true OR appointments.id IS NOT NULL')
+        .available_or_with_appointments(month.to_date.all_month.to_a, appointment_type)
         .pluck(:date)
         .uniq
         .sort

--- a/app/controllers/bex_controller.rb
+++ b/app/controllers/bex_controller.rb
@@ -7,6 +7,7 @@ class BexController < ApplicationController
   # rubocop:disable Metrics/MethodLength
   def agenda_jap
     get_jap_agendas(@appointment_type, params)
+
     @days_with_slots_in_selected_month = days_with_slots(@appointment_type, params[:month])
     @selected_day = selected_day(@days_with_slots_in_selected_month, params)
 
@@ -93,6 +94,8 @@ class BexController < ApplicationController
     Slot.future
         .in_organization(current_organization)
         .where(appointment_type: appointment_type, date: month.to_date.all_month.to_a)
+        .joins('LEFT JOIN appointments ON appointments.slot_id = slots.id')
+        .where('slots.available = true OR appointments.id IS NOT NULL')
         .pluck(:date)
         .uniq
         .sort

--- a/app/models/agenda.rb
+++ b/app/models/agenda.rb
@@ -37,11 +37,8 @@ class Agenda < ApplicationRecord
   end
 
   def slots_for_date(date, appointment_type)
-    slots.where(date: date, appointment_type: appointment_type)
-         # we use LEFT JOIN to get slots with or without appointments
-         .joins('LEFT JOIN appointments ON appointments.slot_id = slots.id')
-         .where('slots.available = true OR appointments.id IS NOT NULL')
+    slots.available_or_with_appointments(date, appointment_type)
          .order(:date, :starting_time)
-         .uniq
+         .distinct
   end
 end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -61,6 +61,13 @@ class Slot < ApplicationRecord
     joins(:appointment_type).merge(AppointmentType.with_slot_types)
   }
 
+  scope :available_or_with_appointments, lambda { |date, appointment_type|
+    where(date: date, appointment_type: appointment_type)
+      # we use LEFT JOIN to get slots with or without appointments
+      .joins('LEFT JOIN appointments ON appointments.slot_id = slots.id')
+      .where('slots.available = true OR appointments.id IS NOT NULL')
+  }
+
   def all_capacity_used?
     used_capacity == capacity
   end

--- a/spec/models/slot_spec.rb
+++ b/spec/models/slot_spec.rb
@@ -152,6 +152,29 @@ RSpec.describe Slot, type: :model do
     end
   end
 
+  describe '.available_or_with_appointments' do
+    let(:date) { Date.today }
+    let(:appointment_type) { create(:appointment_type) }
+
+    let!(:available_slot) { create(:slot, date: date, appointment_type: appointment_type, available: true) }
+    let!(:booked_slot) { create(:slot, date: date, appointment_type: appointment_type, available: false) }
+    let!(:slot_without_appointment) { create(:slot, date: date, appointment_type: appointment_type, available: true) }
+    let!(:slot_unavailable_without_appointment) do
+      create(:slot, date: date, appointment_type: appointment_type, available: false)
+    end
+
+    let!(:appointment) { create(:appointment, slot: booked_slot) }
+
+    it 'returns slots with appointments or available slots for the given date and appointment type' do
+      slots = described_class.available_or_with_appointments(date, appointment_type)
+
+      expect(slots).to include(available_slot)
+      expect(slots).to include(booked_slot)
+      expect(slots).to include(slot_without_appointment)
+      expect(slots).not_to include(slot_unavailable_without_appointment)
+    end
+  end
+
   describe '.in_departments' do
     it 'returns slots scoped by department' do
       department1 = create :department, number: '01', name: 'Ain'


### PR DESCRIPTION
related to https://www.notion.so/monsuivijustice/Le-menu-d-roulant-de-choix-des-dates-des-tableaux-sortie-d-audience-affiche-des-dates-sans-cr-neaux-2caeb1c5a4c44ea698a5ccc488a333b1?pvs=4