### PR TITLE
Fix/check duplicates should use normalized phones

### DIFF
--- a/app/helpers/convicts_helper.rb
+++ b/app/helpers/convicts_helper.rb
@@ -18,8 +18,4 @@ module ConvictsHelper
   def ir_available_services(convict)
     convict.organizations.pluck(:name).join(', ')
   end
-
-  def link_to_convict_show(convict)
-    link_to 'Voir la PPSMJ', convict_path(convict)
-  end
 end

--- a/app/helpers/convicts_helper.rb
+++ b/app/helpers/convicts_helper.rb
@@ -18,4 +18,8 @@ module ConvictsHelper
   def ir_available_services(convict)
     convict.organizations.pluck(:name).join(', ')
   end
+
+  def link_to_convict_show(convict)
+    link_to 'Voir la PPSMJ', convict_path(convict)
+  end
 end

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -199,10 +199,10 @@ class Convict < ApplicationRecord
 
   def find_duplicates
     name_conditions = 'lower(first_name) = ? AND lower(last_name) = ?'
-    normalized_phone = PhonyRails.normalize_number(phone, country_code: 'FR')
+    prefixed_phone = PhonyRails.normalize_number(phone, country_code: 'FR')
 
     duplicates = Convict.kept.where(name_conditions, first_name.downcase, last_name.downcase)
-                        .where('phone = ? OR (date_of_birth = ? AND phone IS NOT NULL)', normalized_phone, date_of_birth)
+                        .where('phone = ? OR (date_of_birth = ? AND phone IS NOT NULL)', prefixed_phone, date_of_birth)
                         .where.not(id: id)
 
     duplicates = duplicates.where(appi_uuid: nil) if appi_uuid.present?

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -199,8 +199,10 @@ class Convict < ApplicationRecord
 
   def find_duplicates
     name_conditions = 'lower(first_name) = ? AND lower(last_name) = ?'
+    normalized_phone = PhonyRails.normalize_number(phone, country_code: 'FR')
+
     duplicates = Convict.kept.where(name_conditions, first_name.downcase, last_name.downcase)
-                        .where('phone = ? OR (date_of_birth = ? AND phone IS NOT NULL)', phone, date_of_birth)
+                        .where('phone = ? OR (date_of_birth = ? AND phone IS NOT NULL)', normalized_phone, date_of_birth)
                         .where.not(id: id)
 
     duplicates = duplicates.where(appi_uuid: nil) if appi_uuid.present?

--- a/spec/features/convicts_spec.rb
+++ b/spec/features/convicts_spec.rb
@@ -212,9 +212,8 @@ RSpec.feature 'Convicts', type: :feature do
         expect(page).to have_link("DUPOND Roberta, suivi(e) par : #{convict.organizations.first.name}",
                                   href: convict_path(convict))
 
-        find('submit-no-appointment')
-
-        expect { click_button('submit-no-appointment') }.to change(Convict, :count).by(1)
+        expect { click_button('submit-no-appointment') }.not_to change(Convict, :count)
+        expect(page).to have_content('Téléphone portable Une PPSMJ est déjà enregistrée avec ce numéro de téléphone.')
       end
     end
 


### PR DESCRIPTION
Relates to https://www.notion.so/monsuivijustice/La-m-thode-check_duplicates-des-convicts-cherche-aussi-parmi-les-PPSMJ-archiv-es-693e9eaae0cc420f8d37907191cfb52b?pvs=4