### PR TITLE
Fix create convict bex

### DIFF
--- a/app/controllers/convicts_controller.rb
+++ b/app/controllers/convicts_controller.rb
@@ -199,25 +199,18 @@ class ConvictsController < ApplicationController
   end
 
   def handle_save_and_redirect(convict)
-    if user_can_use_inter_ressort?(convict)
-      save_and_redirect_with_inter_ressort(convict)
+    convict.update_organizations(current_user)
+    if can_redirect?(convict)
+      redirect_to select_path(params)
     else
       render_new_with_appi_uuid(convict)
     end
   end
 
-  def user_can_use_inter_ressort?(convict)
-    !current_user.can_use_inter_ressort? || convict.valid?(:user_can_use_inter_ressort)
-  end
+  def can_redirect?(convict)
+    return false if current_user.can_use_inter_ressort? && !convict.valid?(:user_can_use_inter_ressort)
 
-  def save_and_redirect_with_inter_ressort(convict)
-    convict.update_organizations(current_user)
-    if convict.save
-      redirect_to select_path(params)
-    else
-      @convict_with_same_appi = Convict.where(appi_uuid: convict.appi_uuid) if convict.errors[:appi_uuid].any?
-      render :new
-    end
+    convict.save
   end
 
   def render_new_with_appi_uuid(convict)

--- a/app/controllers/convicts_controller.rb
+++ b/app/controllers/convicts_controller.rb
@@ -199,18 +199,11 @@ class ConvictsController < ApplicationController
   end
 
   def handle_save_and_redirect(convict)
-    convict.update_organizations(current_user)
-    if can_redirect?(convict)
+    if convict.update_organizations(current_user)
       redirect_to select_path(params)
     else
       render_new_with_appi_uuid(convict)
     end
-  end
-
-  def can_redirect?(convict)
-    return false if current_user.can_use_inter_ressort? && !convict.valid?(:user_can_use_inter_ressort)
-
-    convict.save
   end
 
   def render_new_with_appi_uuid(convict)

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -186,8 +186,6 @@ class Convict < ApplicationRecord
     end
 
     organizations.push(Organization.find_by(name: 'TJ Paris')) if japat
-
-    save
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -34,7 +34,7 @@ class Convict < ApplicationRecord
   validate :phone_uniqueness
   validate :mobile_phone_number, unless: proc { refused_phone? || no_phone? }
 
-  validate :either_city_homeless_lives_abroad_present, on: :user_can_use_inter_ressort
+  validate :either_city_homeless_lives_abroad_present, if: proc { creating_organization&.use_inter_ressort? }
 
   validates_uniqueness_of :date_of_birth, allow_nil: true, scope: %i[first_name last_name],
                                           case_sensitive: false, message: DOB_UNIQUENESS_MESSAGE,
@@ -186,6 +186,7 @@ class Convict < ApplicationRecord
     end
 
     organizations.push(Organization.find_by(name: 'TJ Paris')) if japat
+    save
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity
@@ -207,13 +208,6 @@ class Convict < ApplicationRecord
   end
 
   private
-
-  def at_least_one_organization
-    return unless organizations.blank?
-
-    errors.add(:organizations,
-               I18n.t('activerecord.errors.models.convict.attributes.organizations.blank'))
-  end
 
   def unique_organizations
     return unless organizations.uniq.length != organizations.length

--- a/spec/models/convict_spec.rb
+++ b/spec/models/convict_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe Convict, type: :model do
     it('should not add organization if it is already present') do
       convict = build(:convict, city: nil, organizations: [])
       convict.update_organizations(@current_user)
-
+      convict.save
       expect(convict.organizations).to eq([@current_user.organization])
 
       convict.update_organizations(@current_user)

--- a/spec/models/convict_spec.rb
+++ b/spec/models/convict_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe Convict, type: :model do
     it('should not add organization if it is already present') do
       convict = build(:convict, city: nil, organizations: [])
       convict.update_organizations(@current_user)
-      convict.save
+
       expect(convict.organizations).to eq([@current_user.organization])
 
       convict.update_organizations(@current_user)

--- a/spec/models/convict_spec.rb
+++ b/spec/models/convict_spec.rb
@@ -42,25 +42,6 @@ RSpec.describe Convict, type: :model do
       expect(build(:convict, appi_uuid: nil)).to be_valid
     end
 
-    describe '#at_least_one_organization' do
-      let(:organization1) { Organization.create(name: 'Organization 1') }
-      let(:organization2) { Organization.create(name: 'Organization 2') }
-      let(:convict) { build(:convict, organizations: []) }
-      context 'when convict has at least one organization' do
-        it 'is valid' do
-          convict.organizations << organization1
-          expect(convict).to be_valid
-        end
-      end
-
-      context 'when convict does not have any organizations' do
-        it 'is invalid' do
-          expect(convict).to be_invalid
-          expect(convict.errors[:organizations]).not_to be_empty
-        end
-      end
-    end
-
     describe '#unique_organizations' do
       let(:organization1) { Organization.create(name: 'Organization 1') }
       let(:organization2) { Organization.create(name: 'Organization 2') }
@@ -273,21 +254,23 @@ RSpec.describe Convict, type: :model do
       expect(build(:convict, city: nil, homeless: false, lives_abroad: false)).to be_valid
     end
     context 'when the user is using inter-ressort' do
+      let(:organization) { create(:organization, use_inter_ressort: true) }
       it('is invalid when has no city, dont live abroad and is not homeless') do
-        convict = build(:convict, city: nil, homeless: false, lives_abroad: false)
-        expect(convict.valid?(:user_can_use_inter_ressort)).to be false
+        convict = build(:convict, city: nil, homeless: false, lives_abroad: false, creating_organization: organization)
+        expect(convict.valid?).to be false
       end
       it('is valid when has a city, dont live abroad and is not homeless') do
-        convict = build(:convict, city_id: '12', homeless: false, lives_abroad: false)
-        expect(convict.valid?(:user_can_use_inter_ressort)).to be true
+        convict = build(:convict, city_id: '12', homeless: false, lives_abroad: false,
+                                  creating_organization: organization)
+        expect(convict.valid?).to be true
       end
       it('is valid when has no city, lives abroad and is not homeless') do
-        convict = build(:convict, city: nil, homeless: false, lives_abroad: true)
-        expect(convict.valid?(:user_can_use_inter_ressort)).to be true
+        convict = build(:convict, city: nil, homeless: false, lives_abroad: true, creating_organization: organization)
+        expect(convict.valid?).to be true
       end
       it('is valid when has a city, dont live abroad and is homeless') do
-        convict = build(:convict, city: nil, homeless: true, lives_abroad: false)
-        expect(convict.valid?(:user_can_use_inter_ressort)).to be true
+        convict = build(:convict, city: nil, homeless: true, lives_abroad: false, creating_organization: organization)
+        expect(convict.valid?).to be true
       end
     end
   end
@@ -333,6 +316,7 @@ RSpec.describe Convict, type: :model do
     it('add new organization and not remove the previous ones') do
       convict = build(:convict, city: nil, organizations: [])
       convict.update_organizations(@current_user)
+
       expect(convict.organizations).to eq([@current_user.organization])
 
       convict.update(city: @city)


### PR DESCRIPTION
related to https://www.notion.so/monsuivijustice/Impossible-de-cr-er-un-probationnaire-quand-on-peut-utiliser-l-inter-ressort-18c61132291a409ebefa0b72e35aabcd?pvs=4