### PR TITLE
Allow to modify ppsmj without date of birth in administrate

### DIFF
--- a/app/controllers/admin/convicts_controller.rb
+++ b/app/controllers/admin/convicts_controller.rb
@@ -3,10 +3,10 @@ module Admin
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #
-    # def update
-    #   super
-    #   send_foo_updated_email(requested_resource)
-    # end
+    def update
+      requested_resource.current_user = current_user
+      super
+    end
 
     # Override this method to specify custom lookup behavior.
     # This will be used to set the resource for the `show`, `edit`, and `update`


### PR DESCRIPTION
related to https://www.notion.so/monsuivijustice/Permettre-la-mise-jour-des-PPSMJs-sans-date-de-naissance-depuis-l-interface-administrate-0d3f34877acf4c51814aa2c9dc21cbfc?pvs=4