### PR TITLE
rake task to fix appointments after redis incident

### DIFF
--- a/lib/tasks/fix_appointments.rake
+++ b/lib/tasks/fix_appointments.rake
@@ -1,0 +1,28 @@
+# lib/tasks/appointments.rake
+namespace :appointments do
+  desc "Update state of Appointments from 'created' to 'booked'"
+  task update_state: :environment do
+    # Retrieve all 'created' appointments
+    created_appointments = Appointment.where(state: 'created').where('created_at >= ?', Date.today).includes(:slot)
+
+    created_appointments.each do |appointment|
+      # Check for a 'booked' appointment with the same convict_id, slot date, and starting time
+      conflicting_appointment = Appointment.joins(:slot)
+                                           .where(convict_id: appointment.convict_id,
+                                                  state: 'booked',
+                                                  slots: { date: appointment.slot.date,
+                                                           starting_time: appointment.slot.starting_time })
+                                           .first
+
+      if conflicting_appointment
+        # If conflicting appointment found, delete the 'created' appointment
+        puts "Appointment #{appointment.id} will be destroyed because it is conflicting with appointment #{conflicting_appointment.id}"
+        appointment.destroy
+      else
+        # If no conflicting appointment found, change the state
+        puts "Appointment #{appointment.id} will be booked"
+        appointment.book(send_notification: true)
+      end
+    end
+  end
+end

--- a/lib/tasks/fix_appointments.rake
+++ b/lib/tasks/fix_appointments.rake
@@ -16,8 +16,8 @@ namespace :appointments do
 
       if conflicting_appointment
         # If conflicting appointment found, delete the 'created' appointment
-        puts "Appointment #{appointment.id} will be destroyed because it is conflicting with appointment 
-            #{conflicting_appointment.id}"
+        puts "Appointment #{appointment.id} will be destroyed because it is conflicting with appointment
+             #{conflicting_appointment.id}"
         appointment.destroy
       else
         # If no conflicting appointment found, change the state

--- a/lib/tasks/fix_appointments.rake
+++ b/lib/tasks/fix_appointments.rake
@@ -16,7 +16,8 @@ namespace :appointments do
 
       if conflicting_appointment
         # If conflicting appointment found, delete the 'created' appointment
-        puts "Appointment #{appointment.id} will be destroyed because it is conflicting with appointment #{conflicting_appointment.id}"
+        puts "Appointment #{appointment.id} will be destroyed because it is conflicting with appointment 
+            #{conflicting_appointment.id}"
         appointment.destroy
       else
         # If no conflicting appointment found, change the state

--- a/spec/tasks/fix_appointments_spec.rb
+++ b/spec/tasks/fix_appointments_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'appointments namespace rake tasks' do
+  before :all do
+    Rake.application.rake_require 'tasks/fix_appointments'
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'update_state' do
+    let(:today) { Date.today }
+
+    let!(:organization) { create(:organization, name: 'Test Organization') }
+    let!(:place) { create(:place, organization:) }
+    let!(:agenda) { create(:agenda, name: 'Test Agenda', place:) }
+    let!(:appointment_type) { create(:appointment_type) }
+    let!(:convict) { create(:convict, organizations: [organization]) }
+    let!(:notif_type) do
+      create(:notification_type, appointment_type:, role: :summon, template: 'Blabla', is_default: true)
+    end
+
+    let!(:slot) do
+      Slot.create!(date: today, starting_time: '10:00', appointment_type:, agenda:)
+    end
+
+    let!(:booked_appointment) do
+      Appointment.create!(convict:, slot:, state: 'booked')
+    end
+
+    let!(:created_appointment_conflicting) do
+      Appointment.create!(convict:, slot:, state: 'created', created_at: today)
+    end
+
+    let!(:created_appointment_non_conflicting) do
+      slot_non_conflicting = Slot.create!(date: today, starting_time: '11:00', appointment_type:,
+                                          agenda:)
+      Appointment.create!(convict:, slot: slot_non_conflicting, state: 'created', created_at: today)
+    end
+
+    it 'should destroy conflicting appointments and book non-conflicting ones' do
+      expect do
+        Rake.application.invoke_task('appointments:update_state')
+      end.to change { Appointment.count }.by(-1)
+
+      # Assertions
+      expect(Appointment.exists?(created_appointment_conflicting.id)).to be_falsey
+      expect(created_appointment_non_conflicting.reload.state).to eq('booked')
+    end
+
+    # You can add more examples, for instance:
+    # - When there are no appointments at all.
+    # - When there are only booked appointments.
+    # - When all appointments are non-conflicting.
+  end
+end


### PR DESCRIPTION
- Retrieve all 'created' appointments during the redis failure on Friday, August 11th
- Check for a 'booked' appointment with the same convict_id, slot date, and starting time
- If conflicting appointment found, delete the 'created' appointment
- If no conflicting appointment found, book the appointment using state machine and make sure it sends the sms


