### PR TITLE
[MSJ-603] Bugfix/missed appointment popups use legacy place after transfert

### DIFF
--- a/app/controllers/admin/seeds_controller.rb
+++ b/app/controllers/admin/seeds_controller.rb
@@ -12,6 +12,7 @@ module Admin
     end
 
     def reset_db
+      login_email = true_user.email
       sign_out(true_user)
       sign_out(current_user)
 
@@ -20,7 +21,7 @@ module Admin
       return redirect_to admin_root_path unless Rails.env.development?
 
       Rails.application.load_seed
-      @admin = User.find_by(email: 'admin@example.com')
+      @admin = User.find_by(email: login_email)
       sign_in(@admin)
       redirect_to admin_root_path
     end

--- a/app/dashboards/organization_dashboard.rb
+++ b/app/dashboards/organization_dashboard.rb
@@ -39,6 +39,7 @@ class OrganizationDashboard < Administrate::BaseDashboard
     headquarter
     tjs
     spips
+    places
     number_of_convicts
     use_inter_ressort
   ].freeze

--- a/app/jobs/prepare_place_transfert_job.rb
+++ b/app/jobs/prepare_place_transfert_job.rb
@@ -87,10 +87,16 @@ class PreparePlaceTransfertJob < ApplicationJob
   end
 
   def modify_notif_content(old_place, new_place, notification)
-    notification.content.gsub(old_place.name, new_place.name)
-                .gsub(old_place.adress, new_place.adress)
-                .gsub(old_place.display_phone, new_place.display_phone)
-                .gsub(old_place.contact_email, new_place.contact_email)
-                .gsub(old_place.preparation_link, new_place.preparation_link)
+    attributes = %i[name adress display_phone contact_email preparation_link]
+
+    modified_content = notification.content
+
+    attributes.each do |attr|
+      if old_place.send(attr) && new_place.send(attr)
+        modified_content = modified_content.gsub(old_place.send(attr), new_place.send(attr))
+      end
+    end
+
+    modified_content
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -288,6 +288,7 @@ ActiveRecord::Schema.define(version: 2023_06_22_125651) do
     t.string "name", limit: 255, null: false
     t.string "address", limit: 255, null: false
     t.string "phone", limit: 255, null: false
+    t.string "type", limit: 10
   end
 
   create_table "notification_types", force: :cascade do |t|


### PR DESCRIPTION
FTR : l'essentiel du supposé bug était en fait une erreur utilisateur. Le numéro de téléphone du nouveau lieu n'a pas été mis à jour tout de suite mais bien une semaine après la date de déménagement. C'est pour cette raison que les rendez-vous créés avant la mise en place du nouveau numéro de téléphone avaient des notifs erronées 