### PR TITLE
try to fix brevo dns issue

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,7 +128,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
-    address: 'smtp-relay.brevo.com',
+    address: 'smtp-relay.sendinblue.com',
     port: 587,
     user_name: ENV['SMTP_SIB_ACCOUNT'],
     password: ENV['SMTP_SIB_PWD'],


### PR DESCRIPTION
reponse du support brevo:
Si vous utilisez la plateforme transactionnelle avec [smtp-relay.brevo.com](http://smtp-relay.brevo.com/) et que cela ne fonctionne toujours pas, vous pouvez utiliser [smtp-relay.sendinblue.com](http://smtp-relay.sendinblue.com/), et vous pouvez utiliser [api.](http://api.brevo.com/)[Sendinblue.com](http://sendinblue.com/) pour l'API.