### PR TITLE
removed useless validation context for bex

### DIFF
--- a/app/controllers/convicts_controller.rb
+++ b/app/controllers/convicts_controller.rb
@@ -54,8 +54,6 @@ class ConvictsController < ApplicationController
 
     old_phone = @convict.phone
 
-    return render :edit, status: :unprocessable_entity if bex_user_and_invalid_convict?
-
     update_convict
 
     if @convict.errors.empty?
@@ -182,10 +180,6 @@ class ConvictsController < ApplicationController
 
   def force_duplication?
     ActiveRecord::Type::Boolean.new.deserialize(params.dig(:convict, :force_duplication))
-  end
-
-  def bex_user_and_invalid_convict?
-    current_user.work_at_bex? && !@convict.valid?(:user_works_at_bex)
   end
 
   def update_convict


### PR DESCRIPTION
Les utilisateurs bex ne peuvent pas ajouter de date de naissance à un probationnaire existant qui n'en a pas.