### PR TITLE
Update node

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/nodejs-buildpack.git
+https://github.com/Scalingo/ruby-buildpack.git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.18.0
+          node-version: 20.10.0
 
       - name: Install Ruby dependencies
         run: bundle install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.19.0
+          node-version: 18.18.2
 
       - name: Install Yarn
         run: npm install --global yarn@1.22.19

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           node-version: 20.10.0
 
+      - name: Install Yarn
+        run: npm install --global yarn@1.22.19
+
       - name: Install Ruby dependencies
         run: bundle install
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 20.10.0
+          node-version: 20.9.0
 
       - name: Install Yarn
         run: npm install --global yarn@1.22.19

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 20.9.0
+          node-version: 18.19.0
 
       - name: Install Yarn
         run: npm install --global yarn@1.22.19

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mon-suivi-justice",
   "private": true,
   "engines": {
-    "node": "18.19.0",
+    "node": "18.18.2",
     "yarn": "1.22.19"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mon-suivi-justice",
   "private": true,
   "engines": {
-    "node": "20.9.0",
+    "node": "18.19.0",
     "yarn": "1.22.19"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mon-suivi-justice",
   "private": true,
   "engines": {
-    "node": "20.10.0",
+    "node": "20.9.0",
     "yarn": "1.22.19"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "mon-suivi-justice",
   "private": true,
+  "engines": {
+    "node": "20.10.0",
+    "yarn": "1.22.19"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.5.1",
     "@gouvfr/dsfr": "^1.8.5",


### PR DESCRIPTION
Parce que certaines dépendances, comme https://github.com/betagouv/mon-suivi-justice/pull/446 requierent qu'on monte en version de node.
On ne va pas jusqu'à la 20.10.0 car le buildpack ruby de Scalingo ne permet pas de monter au delà de 20.9.0.