### PR TITLE
Manually added expand arrows to appointments table sorting links

### DIFF
--- a/app/assets/stylesheets/appointments.css
+++ b/app/assets/stylesheets/appointments.css
@@ -279,3 +279,8 @@
 .appointments-link__cancel {
   color: var(--danger);
 }
+
+.sort-link-inline {
+  display: inline-flex;
+  align-items: center;
+}

--- a/app/assets/stylesheets/index.css
+++ b/app/assets/stylesheets/index.css
@@ -185,6 +185,10 @@
   color: black;
   display: flex;
   align-items: center;
+  padding: 1.2em;
+  margin: -1.2em;
+  position: relative;
+  z-index: 1;
 
   .fr-icon-arrow-up-s-line:before, .fr-icon-arrow-down-s-line:before {
     --icon-size: 1rem !important;

--- a/app/helpers/appointments_helper.rb
+++ b/app/helpers/appointments_helper.rb
@@ -37,4 +37,17 @@ module AppointmentsHelper
       t('appointments.waiting_line.for_a_service', orga: organization.name)
     end
   end
+
+  def current_sort_column
+    params[:q]&.fetch(:s, '')&.split(' ')&.first
+  end
+
+  def sort_link_with_expandable_arrow(column, text)
+    link = sort_link(@q, column, text, default_order: :desc)
+    unless current_sort_column == column
+      svg = image_tag('expand-up-down-line.svg', width: 15, style: 'margin-left: 5px')
+    end
+    content = link + svg.to_s
+    "<span class='sort-link-inline'>#{content}</span>".html_safe
+  end
 end

--- a/app/views/shared/_appointments_table.html.erb
+++ b/app/views/shared/_appointments_table.html.erb
@@ -1,4 +1,3 @@
-<p><%= @q.inspect %></p>
 <div class="fr-table fr-table--bordered">
   <table>
     <thead>

--- a/app/views/shared/_appointments_table.html.erb
+++ b/app/views/shared/_appointments_table.html.erb
@@ -1,20 +1,16 @@
+<p><%= @q.inspect %></p>
 <div class="fr-table fr-table--bordered">
   <table>
     <thead>
       <tr>
         <th scope="col"><%= t('activerecord.models.convict', count: 1) %></th>
-        <th scope="col"><%= current_page?(appointments_path) ? sort_link(@q, 'slot_date', t('activerecord.attributes.slot.date'), default_order: :desc) : t('activerecord.attributes.slot.date') %>
-        </th>
-        <th scope="col"><%= current_page?(appointments_path) ? sort_link(@q, 'slot_starting_time', t('activerecord.attributes.slot.starting_time'), default_order: :desc) : t('activerecord.attributes.slot.date') %>
-        </th>
-        <th scope="col"><%= current_page?(appointments_path) ? sort_link(@q, 'slot_agenda_place_name', t('activerecord.models.place'), default_order: :desc) : t('activerecord.attributes.slot.date') %>
-        </th>
-        <th scope="col"><%= current_page?(appointments_path) ? sort_link(@q, 'slot_agenda_name', t('activerecord.models.agenda'), default_order: :desc) : t('activerecord.attributes.slot.date') %>
-        </th>
-        <th scope="col"><%= current_page?(appointments_path) ? sort_link(@q, 'slot_appointment_type_name', t('activerecord.attributes.slot.appointment_type'), default_order: :desc) : t('activerecord.attributes.slot.date') %>
-        </th>
+        <th scope="col"><%= sort_link_with_expandable_arrow('slot_date', t('activerecord.attributes.slot.date')) %></th>
+        <th scope="col"><%= sort_link_with_expandable_arrow('slot_starting_time', t('activerecord.attributes.slot.starting_time')) %></th>
+        <th scope="col"><%= sort_link_with_expandable_arrow('slot_agenda_place_name', t('activerecord.models.place')) %></th>
+        <th scope="col"><%= sort_link_with_expandable_arrow('slot_agenda_name', t('activerecord.models.agenda')) %></th>
+        <th scope="col"><%= sort_link_with_expandable_arrow('slot_appointment_type_name', t('activerecord.attributes.slot.appointment_type')) %></th>
         <% if current_user.work_at_spip? %>
-          <th><%= t('index-user-filter')%></th>
+          <th><%= t('index-user-filter') %></th>
         <% end %>
         <th scope="col">
           <div class="fr-grid-row fr-grid-row--center">

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -2,6 +2,5 @@ Ransack.configure do |config|
   config.custom_arrows = {
     up_arrow: "<span class='fr-icon-arrow-up-s-line fr-icon-sm' aria-hidden='true'></span>",
     down_arrow: "<span class='fr-icon-arrow-down-s-line fr-icon-sm' aria-hidden='true'></span>",
-    default_arrow: "<img src='#{ActionController::Base.helpers.asset_path("expand-up-down-line.svg")}' class='table-header__arrows--expand' alt='expand'>"
   }
 end

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,11 +1,7 @@
 Ransack.configure do |config|
-  asset_filename = Rails.application.assets_manifest.assets['expand-up-down-line.svg'] || 'expand-up-down-line.svg'
-  base_path = Rails.env.production? ? "" : "/assets"
-
-
   config.custom_arrows = {
     up_arrow: "<span class='fr-icon-arrow-up-s-line fr-icon-sm' aria-hidden='true'></span>",
     down_arrow: "<span class='fr-icon-arrow-down-s-line fr-icon-sm' aria-hidden='true'></span>",
-    default_arrow: "<img src='#{base_path}/#{asset_filename}' class='table-header__arrows--expand' alt='expand'>"
+    default_arrow: "<img src='#{ActionController::Base.helpers.asset_path("expand-up-down-line.svg")}' class='table-header__arrows--expand' alt='expand'>"
   }
 end

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,7 +1,9 @@
 Ransack.configure do |config|
+  assets_base_path = Rails.env.production? ? "/assets" : "assets"
+
   config.custom_arrows = {
     up_arrow: "<span class='fr-icon-arrow-up-s-line fr-icon-sm' aria-hidden='true'></span>",
     down_arrow: "<span class='fr-icon-arrow-down-s-line fr-icon-sm' aria-hidden='true'></span>",
-    default_arrow: "<img src='assets/expand-up-down-line.svg' class='table-header__arrows--expand' alt='expand'>"
+    default_arrow: "<img src='#{assets_base_path}/expand-up-down-line.svg' class='table-header__arrows--expand' alt='expand'>"
   }
 end

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,9 +1,11 @@
 Ransack.configure do |config|
-  assets_base_path = Rails.env.production? ? "/assets" : "assets"
+  asset_filename = Rails.application.assets_manifest.assets['expand-up-down-line.svg'] || 'expand-up-down-line.svg'
+  base_path = Rails.env.production? ? "" : "/assets"
+
 
   config.custom_arrows = {
     up_arrow: "<span class='fr-icon-arrow-up-s-line fr-icon-sm' aria-hidden='true'></span>",
     down_arrow: "<span class='fr-icon-arrow-down-s-line fr-icon-sm' aria-hidden='true'></span>",
-    default_arrow: "<img src='#{assets_base_path}/expand-up-down-line.svg' class='table-header__arrows--expand' alt='expand'>"
+    default_arrow: "<img src='#{base_path}/#{asset_filename}' class='table-header__arrows--expand' alt='expand'>"
   }
 end


### PR DESCRIPTION
Impossible d'utiliser des icônes remixicon dans la conf de ransack. 
Les helpers d'assets ne fonctionnent pas dans ce contexte. 
Voici une alternative.