### PR TITLE
[MSJ-980] spip auto accept

### DIFF
--- a/app/controllers/convicts_controller.rb
+++ b/app/controllers/convicts_controller.rb
@@ -39,9 +39,7 @@ class ConvictsController < ApplicationController
     authorize @convict
 
     if @convict.save
-      if params[:invite_convict] == 'on' && ConvictInvitationPolicy.new(current_user, @convict).create?
-        InviteConvictJob.perform_later(@convict.id)
-      end
+      handle_convict_interface_invitation
       redirect_to select_path(params), notice: t('.notice')
     else
       @duplicate_convict = find_duplicate_convict
@@ -232,5 +230,11 @@ class ConvictsController < ApplicationController
     @convict.creating_organization = current_organization
     @convict.current_user = current_user
     @convict.update_organizations(current_user, autosave: false)
+  end
+
+  def handle_convict_interface_invitation
+    return unless params[:invite_convict] == 'on' && ConvictInvitationPolicy.new(current_user, @convict).create?
+
+    InviteConvictJob.perform_later(@convict.id)
   end
 end

--- a/app/models/organization_divestment.rb
+++ b/app/models/organization_divestment.rb
@@ -2,5 +2,8 @@ class OrganizationDivestment < ApplicationRecord
   belongs_to :organization
   belongs_to :divestment
 
+  enum state: { pending: 'pending', auto_accepted: 'auto_accepted', accepted: 'accepted',
+                refused: 'refused', ignored: 'ignored' }
+
   validates :comment, length: { maximum: 120 }, allow_blank: true
 end

--- a/app/services/divestment_creator_service.rb
+++ b/app/services/divestment_creator_service.rb
@@ -1,5 +1,7 @@
 # app/services/divestment_creator.rb
 class DivestmentCreatorService
+  attr_reader :convict, :user, :divestment
+
   def initialize(convict, user, divestment)
     @convict = convict
     @user = user
@@ -36,12 +38,18 @@ class DivestmentCreatorService
 
   def create_organization_divestments(divestment, state)
     @convict.organizations.each do |org|
-      org_state = org.users.where(role: 'local_admin').empty? ? 'ignored' : state
+      org_state = initial_state(org, state)
       OrganizationDivestment.create!(
         divestment_id: divestment.id,
         organization_id: org.id,
         state: org_state
       )
     end
+  end
+
+  def initial_state(org, state)
+    return 'auto_accepted' if org.spip? && @convict.organizations.intersect?(org.tjs)
+
+    org.users.where(role: 'local_admin').empty? ? 'ignored' : state
   end
 end

--- a/spec/features/divestments_spec.rb
+++ b/spec/features/divestments_spec.rb
@@ -4,14 +4,14 @@ RSpec.feature 'Divestments', type: :feature do
   describe 'creation' do
     context 'appointment_type with predefined slots' do
       before do
-        @convict = create(:convict, first_name: 'Joe', last_name: 'Dalton', appi_uuid: '123456789')
+        @convict = create(:convict, first_name: 'Joe', last_name: 'Dalton')
         create(:user, role: :local_admin, organization: @convict.organizations.last)
       end
 
       it 'allows user to create a divestment', logged_in_as: 'cpip', js: true do
         visit new_convict_path
 
-        fill_in 'N° dossier APPI', with: '123456789'
+        fill_in 'N° dossier APPI', with: @convict.appi_uuid
 
         expect { click_button 'submit-with-appointment' }.not_to(change { Convict.count })
 

--- a/spec/models/convict_spec.rb
+++ b/spec/models/convict_spec.rb
@@ -234,35 +234,6 @@ RSpec.describe Convict, type: :model do
     end
   end
 
-  describe '.check_duplicates' do
-    before do
-      @user = create_admin_user_and_login
-    end
-
-    it 'adds duplicate if names are the same' do
-      convict1 = create(:convict, first_name: 'Jean Louis', last_name: 'Martin',
-                                  appi_uuid: nil, date_of_birth: '1980-01-01')
-      convict2 = build(:convict, first_name: 'Jean Louis', last_name: 'Martin',
-                                 appi_uuid: nil, date_of_birth: '1980-01-01')
-      convict2.save(validate: false)
-      convict1.check_duplicates
-
-      expect(convict1.duplicates).to eq([convict2])
-    end
-
-    it "doesn't add duplicate if appi_uuid are different" do
-      convict1 = create(:convict, first_name: 'Jean Louis', last_name: 'Martin',
-                                  appi_uuid: "2024#{Faker::Number.unique.number(digits: 8)}",
-                                  date_of_birth: '1980-01-01')
-      create(:convict, first_name: 'Jean Louis', last_name: 'Martin',
-                       appi_uuid: "2024#{Faker::Number.unique.number(digits: 8)}", date_of_birth: '1980-01-01')
-
-      convict1.check_duplicates
-
-      expect(convict1.duplicates).to be_empty
-    end
-  end
-
   describe 'either_city_homeless_lives_abroad_present' do
     it('is valid when the user is not using inter-ressort') do
       expect(build(:convict, city: nil, homeless: false, lives_abroad: false)).to be_valid
@@ -380,7 +351,7 @@ RSpec.describe Convict, type: :model do
       end
 
       it 'is valid with a duplicate date_of_birth, first_name, and last_name but with appi_uuid' do
-        convict_with_appi_uuid = build(:convict, first_name:, last_name:, date_of_birth:, appi_uuid: '123456')
+        convict_with_appi_uuid = build(:convict, first_name:, last_name:, date_of_birth:)
         expect(convict_with_appi_uuid).to be_valid
       end
     end

--- a/spec/services/divestment_creator_service_spec.rb
+++ b/spec/services/divestment_creator_service_spec.rb
@@ -35,6 +35,25 @@ RSpec.describe DivestmentCreatorService do
       end
     end
 
+    context 'when organizations are SPIP and TJS' do
+      let(:tj) { create(:organization, organization_type: :tj) }
+      let(:spip) do
+        spip = build(:organization, organization_type: :spip)
+        spip.tjs = [tj]
+        spip.save
+        spip
+      end
+
+      let(:convict) { create(:convict, organizations: [tj, spip]) }
+
+      it 'creates organization divestments with auto_accepted state for spip if tj' do
+        service.call
+        expect(service.divestment.organization_divestments.count).to eq(2)
+        expect(service.divestment.organization_divestments.find_by(organization: spip).state).to eq('auto_accepted')
+        expect(service.divestment.organization_divestments.find_by(organization: tj).state).to eq('ignored')
+      end
+    end
+
     context 'when the convict is discarded' do
       before do
         allow(convict).to receive(:discarded?).and_return(true)


### PR DESCRIPTION
Evolution poste réu des ambassadeurs: pour un probationnaire donné, s’il est lié à un ou des TJ, ce sont seulement eux qui peuvent valider le dessaisissement. S’il n’est pas lié à des TJ c’est son ou ses SPIPs qui doivent le faire. Même si le le SPIP n’a pas son mot a dire, il est quand même prévenu.
—> Proposition : Le SPIP est passé en automatiquement validé s’il n’a pas de réponse à donner.