### PR TITLE
Broadcast invitation result

### DIFF
--- a/app/controllers/convict_invitations_controller.rb
+++ b/app/controllers/convict_invitations_controller.rb
@@ -5,8 +5,11 @@ class ConvictInvitationsController < ApplicationController
     @convict = Convict.find(params[:convict_id])
     authorize @convict, policy_class: ConvictInvitationPolicy
 
-    InviteConvictJob.perform_later(@convict.id)
+    InviteConvictJob.perform_later(@convict.id, current_user.id)
 
-    redirect_to convict_path(@convict), notice: t('.invitation_pending')
+    respond_to do |format|
+      format.html { redirect_to convict_path(@convict), notice: t('.invitation_pending') }
+      format.turbo_stream { flash.now[:notice] = t('.invitation_pending') }
+    end
   end
 end

--- a/app/controllers/convict_invitations_controller.rb
+++ b/app/controllers/convict_invitations_controller.rb
@@ -5,7 +5,7 @@ class ConvictInvitationsController < ApplicationController
     @convict = Convict.find(params[:convict_id])
     authorize @convict, policy_class: ConvictInvitationPolicy
 
-    InviteConvictJob.perform_later(@convict.id, current_user.id)
+    InviteConvictJob.perform_later(@convict.id)
 
     respond_to do |format|
       format.html { redirect_to convict_path(@convict), notice: t('.invitation_pending') }

--- a/app/controllers/convicts_controller.rb
+++ b/app/controllers/convicts_controller.rb
@@ -200,7 +200,7 @@ class ConvictsController < ApplicationController
 
   def handle_successful_update(old_phone)
     record_phone_change(old_phone)
-    flash.now[:success] = 'Le probationnaire a bien été mise à jour'
+    flash[:success] = 'Le probationnaire a bien été mise à jour'
     redirect_to convict_path(@convict)
   end
 

--- a/app/jobs/invite_convict_job.rb
+++ b/app/jobs/invite_convict_job.rb
@@ -2,7 +2,7 @@ class InviteConvictJob < ApplicationJob
   sidekiq_options retry: 5
 
   queue_as :default
-  def perform(convict_id)
+  def perform(convict_id, user_id = nil)
     @convict = Convict.find(convict_id)
     return unless @convict.phone.present?
 
@@ -12,5 +12,13 @@ class InviteConvictJob < ApplicationJob
     MonSuiviJusticePublicApi::Invitation.create(params)
     @convict.increment!(:invitation_to_convict_interface_count)
     @convict.update(last_invite_to_convict_interface: Time.zone.now)
+    return unless user_id.present?
+
+    sleep 3 # without sleep, the broadcast can happen before the show page is loaded
+    user = User.find(user_id)
+    Turbo::StreamsChannel.broadcast_replace_to [user, @convict, 'convict_invitation_card'],
+                                               partial: 'convicts/invitation_card',
+                                               locals: { convict: @convict, user: },
+                                               target: 'convict_invitation_card'
   end
 end

--- a/app/jobs/invite_convict_job.rb
+++ b/app/jobs/invite_convict_job.rb
@@ -2,7 +2,7 @@ class InviteConvictJob < ApplicationJob
   sidekiq_options retry: 5
 
   queue_as :default
-  def perform(convict_id, user_id = nil)
+  def perform(convict_id)
     @convict = Convict.find(convict_id)
     return unless @convict.phone.present?
 
@@ -12,13 +12,5 @@ class InviteConvictJob < ApplicationJob
     MonSuiviJusticePublicApi::Invitation.create(params)
     @convict.increment!(:invitation_to_convict_interface_count)
     @convict.update(last_invite_to_convict_interface: Time.zone.now)
-    return unless user_id.present?
-
-    sleep 3 # without sleep, the broadcast can happen before the show page is loaded
-    user = User.find(user_id)
-    Turbo::StreamsChannel.broadcast_replace_to [user, @convict, 'convict_invitation_card'],
-                                               partial: 'convicts/invitation_card',
-                                               locals: { convict: @convict, user: },
-                                               target: 'convict_invitation_card'
   end
 end

--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -50,6 +50,11 @@ class Convict < ApplicationRecord
 
   validates_with AppiUuidValidator
 
+  after_update_commit lambda {
+                        broadcast_replace_to [self, 'convict_invitation_card'], partial: 'convicts/invitation_card',
+                                                                                locals: { convict: self, can_invite: true },
+                                                                                target: 'convict_invitation_card'
+                      }
   after_update :update_convict_api
   after_destroy :delete_convict_from_node_app, if: :timestamp_convict_interface_creation
 

--- a/app/views/convict_invitations/create.turbo_stream.erb
+++ b/app/views/convict_invitations/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.update "flash_messages", partial: "shared/flashes" %>
+<%= turbo_stream.replace 'convict_invitation_card', partial: 'convicts/invitation_card', locals: { convict: @convict, user: current_user } %>

--- a/app/views/convict_invitations/create.turbo_stream.erb
+++ b/app/views/convict_invitations/create.turbo_stream.erb
@@ -1,2 +1,2 @@
 <%= turbo_stream.update "flash_messages", partial: "shared/flashes" %>
-<%= turbo_stream.replace 'convict_invitation_card', partial: 'convicts/invitation_card', locals: { convict: @convict, user: current_user } %>
+<%= turbo_stream.replace 'convict_invitation_card', partial: 'convicts/invitation_card', locals: { convict: @convict, can_invite: ConvictInvitationPolicy.new(current_user, @convict).create? } %>

--- a/app/views/convicts/_invitation_card.html.erb
+++ b/app/views/convicts/_invitation_card.html.erb
@@ -1,63 +1,43 @@
-<%= turbo_stream_from user, convict, "convict_invitation_card" %>
+<%= turbo_stream_from convict, "convict_invitation_card" if can_invite %>
 <%= turbo_frame_tag "convict_invitation_card" do %>
-  <% if ConvictInvitationPolicy.new(user, convict).create? || convict.already_invited_to_interface? %>
-    <div class="fr-grid-row fr-mt-2w">
-      <div class="fr-col">
-        <div class="fr-card fr-p-2w">
-          <div class="fr-grid-row  fr-grid-row--middle">
-            <div class="fr-col-4">
-              <h3 class="fr-mr-2w"><%= t('.title') %></h3>
-            </div>
-            <div class="fr-col-8 ">
-              <div class="fr-grid-row  fr-grid-row--right">
-                <ul class="fr-btns-group fr-btns-group--inline-lg">
-                  <% if ConvictInvitationPolicy.new(user, convict).create? %>
-                    <%= button_to convict.invitation_to_convict_interface_count == 1 ? t('.reinvite') : t('.invite'), convict_invitation_path(convict), class: 'fr-btn fr-btn--secondary', id: 'convict-invitation-button', disabled: flash[:notice] == t('convict_invitations.create.invitation_pending') || convict.invitation_to_convict_interface_count >= 2 %>
-                  <% end %>
-                </ul>
-              </div>
-            </div>
+  <div class="fr-grid-row fr-mt-2w">
+    <div class="fr-col">
+      <div class="fr-card fr-p-2w">
+        <div class="fr-grid-row  fr-grid-row--middle">
+          <div class="fr-col-4">
+            <h3 class="fr-mr-2w"><%= t('.title') %></h3>
           </div>
-          <div>
-            <p>
-              <strong><%= t('.interface_invitation_state') %></strong> :
-              <span id="convict-invitation-text">
-                <% if flash[:notice] == t('convict_invitations.create.invitation_pending') %>
-                  <%= t("convict_invitations.create.invitation_pending") %>
-                <% else %>
-                  <%= t(".#{convict.interface_invitation_state}", last_invite: convict.last_invite_to_convict_interface.present? ? l(convict.last_invite_to_convict_interface, format: :clear) : nil) %>
+          <div class="fr-col-8 ">
+            <div class="fr-grid-row  fr-grid-row--right">
+              <ul class="fr-btns-group fr-btns-group--inline-lg">
+                <% if can_invite %>
+                  <%= button_to convict.invitation_to_convict_interface_count == 1 ? t('.reinvite') : t('.invite'), convict_invitation_path(convict), class: 'fr-btn fr-btn--secondary', id: 'convict-invitation-button', disabled: flash[:notice] == t('convict_invitations.create.invitation_pending') || convict.invitation_to_convict_interface_count >= 2 %>
                 <% end %>
-              </span>
-            </p>
-            <p>
-              <strong><%= t('.interface_access_timestamp')%></strong> :
-              <% if convict.can_access_convict_inferface? %>
-                <%= l(convict.timestamp_convict_interface_creation, format: :clear) %>
-              <% else %>
-                <%= t('.interface_no_access') %>
-              <% end %>
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  <% elsif user.can_invite_to_convict_interface?(convict) && !convict.can_receive_sms? %>
-    <div class="fr-grid-row fr-mt-2w">
-      <div class="fr-col">
-        <div class="fr-card fr-p-2w">
-          <div class="fr-grid-row  fr-grid-row--middle">
-            <div class="fr-col-4">
-              <h3 class="fr-mr-2w"><%= t('.title') %></h3>
+              </ul>
             </div>
           </div>
-          <div>
-            <p>
-              <strong><%= t('.cannot_invite') %></strong><br>
-              <%= t('.cannot_invite_reason') %>
-            </p>
-          </div>
+        </div>
+        <div>
+          <p>
+            <strong><%= t('.interface_invitation_state') %></strong> :
+            <span id="convict-invitation-text">
+              <% if flash[:notice] == t('convict_invitations.create.invitation_pending') %>
+                <%= t("convict_invitations.create.invitation_pending") %>
+              <% else %>
+                <%= t(".#{convict.interface_invitation_state}", last_invite: convict.last_invite_to_convict_interface.present? ? l(convict.last_invite_to_convict_interface, format: :clear) : nil) %>
+              <% end %>
+            </span>
+          </p>
+          <p>
+            <strong><%= t('.interface_access_timestamp')%></strong> :
+            <% if convict.can_access_convict_inferface? %>
+              <%= l(convict.timestamp_convict_interface_creation, format: :clear) %>
+            <% else %>
+              <%= t('.interface_no_access') %>
+            <% end %>
+          </p>
         </div>
       </div>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/convicts/_invitation_card.html.erb
+++ b/app/views/convicts/_invitation_card.html.erb
@@ -1,60 +1,63 @@
-<% if ConvictInvitationPolicy.new(user, convict).create? || convict.already_invited_to_interface? %>
-  <div class="fr-grid-row fr-mt-2w">
-    <div class="fr-col">
-      <div class="fr-card fr-p-2w">
-        <div class="fr-grid-row  fr-grid-row--middle">
-          <div class="fr-col-4">
-            <h3 class="fr-mr-2w"><%= t('.title') %></h3>
-          </div>
-          <div class="fr-col-8 ">
-            <div class="fr-grid-row  fr-grid-row--right">
-              <ul class="fr-btns-group fr-btns-group--inline-lg">
-                <% if ConvictInvitationPolicy.new(current_user, convict).create? %>
-                  <%= button_to convict.invitation_to_convict_interface_count == 1 ? t('.reinvite') : t('.invite'), convict_invitation_path(convict), class: 'fr-btn fr-btn--secondary', id: 'convict-invitation-button', data: { turbo: false }, disabled: flash[:notice] == t('convict_invitations.create.invitation_pending') || convict.invitation_to_convict_interface_count == 2 %>
-                <% end %>
-              </ul>
+<%= turbo_stream_from user, convict, "convict_invitation_card" %>
+<%= turbo_frame_tag "convict_invitation_card" do %>
+  <% if ConvictInvitationPolicy.new(user, convict).create? || convict.already_invited_to_interface? %>
+    <div class="fr-grid-row fr-mt-2w">
+      <div class="fr-col">
+        <div class="fr-card fr-p-2w">
+          <div class="fr-grid-row  fr-grid-row--middle">
+            <div class="fr-col-4">
+              <h3 class="fr-mr-2w"><%= t('.title') %></h3>
+            </div>
+            <div class="fr-col-8 ">
+              <div class="fr-grid-row  fr-grid-row--right">
+                <ul class="fr-btns-group fr-btns-group--inline-lg">
+                  <% if ConvictInvitationPolicy.new(user, convict).create? %>
+                    <%= button_to convict.invitation_to_convict_interface_count == 1 ? t('.reinvite') : t('.invite'), convict_invitation_path(convict), class: 'fr-btn fr-btn--secondary', id: 'convict-invitation-button', disabled: flash[:notice] == t('convict_invitations.create.invitation_pending') || convict.invitation_to_convict_interface_count >= 2 %>
+                  <% end %>
+                </ul>
+              </div>
             </div>
           </div>
-        </div>
-        <div>
-          <p>
-            <strong><%= t('.interface_invitation_state') %></strong> :
-            <span id="convict-invitation-text">
-              <% if flash[:notice] == t('convict_invitations.create.invitation_pending') %>
-                <%= t("convict_invitations.create.invitation_pending") %>
+          <div>
+            <p>
+              <strong><%= t('.interface_invitation_state') %></strong> :
+              <span id="convict-invitation-text">
+                <% if flash[:notice] == t('convict_invitations.create.invitation_pending') %>
+                  <%= t("convict_invitations.create.invitation_pending") %>
+                <% else %>
+                  <%= t(".#{convict.interface_invitation_state}", last_invite: convict.last_invite_to_convict_interface.present? ? l(convict.last_invite_to_convict_interface, format: :clear) : nil) %>
+                <% end %>
+              </span>
+            </p>
+            <p>
+              <strong><%= t('.interface_access_timestamp')%></strong> :
+              <% if convict.can_access_convict_inferface? %>
+                <%= l(convict.timestamp_convict_interface_creation, format: :clear) %>
               <% else %>
-                <%= t(".#{convict.interface_invitation_state}", last_invite: convict.last_invite_to_convict_interface.present? ? l(convict.last_invite_to_convict_interface, format: :clear) : nil) %>
+                <%= t('.interface_no_access') %>
               <% end %>
-            </span>
-          </p>
-          <p>
-            <strong><%= t('.interface_access_timestamp')%></strong> :
-            <% if convict.can_access_convict_inferface? %>
-              <%= l(convict.timestamp_convict_interface_creation, format: :clear) %>
-            <% else %>
-              <%= t('.interface_no_access') %>
-            <% end %>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-<% elsif current_user.can_invite_to_convict_interface?(convict) && !convict.can_receive_sms? %>
-  <div class="fr-grid-row fr-mt-2w">
-    <div class="fr-col">
-      <div class="fr-card fr-p-2w">
-        <div class="fr-grid-row  fr-grid-row--middle">
-          <div class="fr-col-4">
-            <h3 class="fr-mr-2w"><%= t('.title') %></h3>
+            </p>
           </div>
         </div>
-        <div>
-          <p>
-            <strong><%= t('.cannot_invite') %></strong><br>
-            <%= t('.cannot_invite_reason') %>
-          </p>
+      </div>
+    </div>
+  <% elsif user.can_invite_to_convict_interface?(convict) && !convict.can_receive_sms? %>
+    <div class="fr-grid-row fr-mt-2w">
+      <div class="fr-col">
+        <div class="fr-card fr-p-2w">
+          <div class="fr-grid-row  fr-grid-row--middle">
+            <div class="fr-col-4">
+              <h3 class="fr-mr-2w"><%= t('.title') %></h3>
+            </div>
+          </div>
+          <div>
+            <p>
+              <strong><%= t('.cannot_invite') %></strong><br>
+              <%= t('.cannot_invite_reason') %>
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/convicts/show.html.erb
+++ b/app/views/convicts/show.html.erb
@@ -107,7 +107,29 @@
         </div>
       </div>
     </div>
-    <%= render 'invitation_card', convict: @convict, user: current_user %>
+    <% if ConvictInvitationPolicy.new(current_user, @convict).create? %>
+      <%= render 'invitation_card', convict: @convict, can_invite: true %>
+    <% elsif @convict.already_invited_to_interface? %>
+      <%= render 'invitation_card', convict: @convict, can_invite: false %>
+    <% elsif current_user.can_invite_to_convict_interface?(@convict) && !@convict.can_receive_sms? %>
+      <div class="fr-grid-row fr-mt-2w">
+        <div class="fr-col">
+          <div class="fr-card fr-p-2w">
+            <div class="fr-grid-row  fr-grid-row--middle">
+              <div class="fr-col-4">
+                <h3 class="fr-mr-2w"><%= t('.invitation_title') %></h3>
+              </div>
+            </div>
+            <div>
+              <p>
+                <strong><%= t('.cannot_invite') %></strong><br>
+                <%= t('.cannot_invite_reason') %>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
     <% if @convict.future_appointments.count(:id) != 0 %>
       <div class="fr-grid-row fr-mt-2w">
         <div class="fr-col">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,12 +85,12 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
-  
+
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
 
   # Better logging
-  config.lograge.enabled = true
+  config.lograge.enabled = false
 
   # lograge custom options (sensitive attributes are hidden by rails config.filter_parameter)
   config.lograge.custom_options = lambda do |event|

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -52,10 +52,12 @@ fr:
     edit:
       cpip_label: "CPIP"
       cpip_blank_option: "Suivi affecté au service"
-    invitation_card:
-      title: Espace probationnaire
+    show:
+      invitation_title: Espace probationnaire
       cannot_invite: Impossible d'inviter ce probationnaire
       cannot_invite_reason: Il n'a pas renseigné de numéro de téléphone ou ne souhaite pas recevoir de SMS
+    invitation_card:
+      title: Espace probationnaire
       invite: Inviter à son espace
       reinvite: Relancer l'invitation
       interface_invitation_state: État de l'invitation

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -722,8 +722,7 @@ fr:
 
   convict_invitations:
     create:
-      invitation_pending: L'invitation est en cours d'envoi au probationnaire. Rafraîchir la page pour actualiser le statut.
-      invitation_sent: L'invitation a été envoyée au probationnaire
+      invitation_pending: L'invitation est en cours d'envoi au probationnaire.
 
   shared:
     environment_alert:


### PR DESCRIPTION
Bon, j'ai un peu fait joujou afin de ne pas avoir besoin de reloader la page post invitation pour voir le résultat.

Ca marche normalement mais c'est aussi très complexe pour pas grand chose. Et ce n'est clairement pas une bonne pratique (cf: https://discuss.hotwired.dev/t/authentication-and-devise-with-broadcasts/1752/26). Je ne suis pas certain que ça mérite d'être mergé.

La gestion du current_user notamment est assez relou. J'ai dû le virer du la partial pour finir.

Update: je viens de me rendre compte d'une faille: si j'update le proba depuis la console, permet à un user qui ne devrait pas pouvoir d'inviter ce proba. Il faudrait donc aussi virer la notion de can_invite de la partiale. Je vais clôturer cette PR qui servira de référence mais à mon avis j'y ai déjà passé trop de temps et ça ne vaut pas le coup d'aller au bout. J'y reviendrai peut être un jour.