### PR TITLE
Display an error when slot is nil

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -139,6 +139,8 @@ class Appointment < ApplicationRecord
   end
 
   def in_organization?(orga)
+    return false if slot.nil?
+
     organization == orga
   end
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -31,7 +31,7 @@ class Appointment < ApplicationRecord
   delegate :name, :adress, :phone, :contact_email, :main_contact_method,
            to: :place, prefix: true
   delegate :name, to: :organization, prefix: true
-  delegate :phone, to: :convict, prefix: true
+  delegate :phone, :name, to: :convict, prefix: true
 
   attr_accessor :place_id, :agenda_id, :department_id, :user_is_cpip, :send_sms
 

--- a/app/policies/appointment_policy.rb
+++ b/app/policies/appointment_policy.rb
@@ -74,7 +74,8 @@ class AppointmentPolicy < ApplicationPolicy
     # condition would always make it true and we need to handle inter ressort for bex
     return true if user.work_at_bex? && user.organization.use_inter_ressort
 
-    return record.in_jurisdiction?(user.organization) if (user.work_at_bex? && record.slot&.appointment_type&.used_at_bex?) ||
+    return record.in_jurisdiction?(user.organization) if (user.work_at_bex? &&
+                                                          record.slot&.appointment_type&.used_at_bex?) ||
                                                          (user.local_admin_tj? &&
                                                          record.slot&.appointment_type&.used_by_local_admin_tj?) ||
                                                          user.admin?

--- a/app/policies/appointment_policy.rb
+++ b/app/policies/appointment_policy.rb
@@ -74,9 +74,9 @@ class AppointmentPolicy < ApplicationPolicy
     # condition would always make it true and we need to handle inter ressort for bex
     return true if user.work_at_bex? && user.organization.use_inter_ressort
 
-    return record.in_jurisdiction?(user.organization) if (user.work_at_bex? && record.appointment_type.used_at_bex?) ||
+    return record.in_jurisdiction?(user.organization) if (user.work_at_bex? && record.slot&.appointment_type&.used_at_bex?) ||
                                                          (user.local_admin_tj? &&
-                                                         record.appointment_type.used_by_local_admin_tj?) ||
+                                                         record.slot&.appointment_type&.used_by_local_admin_tj?) ||
                                                          user.admin?
     # Les agents SAP doivent pouvoir prendre des convocations SAP DDSE au SPIP
     return record.in_jurisdiction?(user.organization) if user.work_at_sap? && record.appointment_type.ddse?

--- a/app/views/shared/_appointment_card.html.erb
+++ b/app/views/shared/_appointment_card.html.erb
@@ -1,5 +1,11 @@
 <tr>
-  <td><%= appointment.convict.name %></td>
+  <td>
+    <% if policy(appointment.convict).show? %>
+      <%= link_to appointment.convict_name, convict_path(appointment.convict), class: 'index-control' %>
+    <% else %>
+      <%= appointment.convict_name %>
+    <% end %>
+  </td>
   <td><%= appointment.slot.date.to_fs(:base_date_format) %></td>
   <td><%= appointment.localized_time.to_fs(:time) %></td>
   <td><%= appointment.slot.agenda.place.name %></td>
@@ -35,9 +41,7 @@
   </td>
   <td>
     <% if policy(appointment).show? %>
-
-        <%= link_to "Voir", appointment_path(appointment), class: 'index-control' %>
-
+      <%= link_to "Voir", appointment_path(appointment), class: 'index-control' %>
     <% end %>
     <% if policy(appointment).cancel? && appointment.slot.date.after?(DateTime.current) %>
       <%= link_to t('cancel'), appointment_cancel_path(appointment),


### PR DESCRIPTION
Fix https://sentry.incubateur.net/organizations/betagouv/issues/95490/?query=is%3Aunresolved&referrer=issue-stream en affichant un flash à l'utilisateur quand il n'y a pas de slot associé à la convocation. Comme ce n'est pas censé arrivé je suis un peu partagé sur mon approche. Je n'ai pas trouvé la cause de fond qui fait que c'était arrivé. Mais du coup est-ce qu'on veut faire péter l'app pour être prévenus (comme actuellement) ou afficher une erreur à l'agent (comme dans cette PR) ? En plus je ne trouve pas ma solution très clean (mais faut naviguer dans la dette technique ahah)