### PR TITLE
Easy fix active record not found for send notification job

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -80,7 +80,8 @@ class Notification < ApplicationRecord
     end
 
     after_transition on: :send_now do |notification|
-      SmsDeliveryJob.perform_later(notification.id)
+      SmsDeliveryJob.set(wait: 10.seconds)
+                    .perform_later(notification.id)
     end
 
     after_transition on: :program do |notification|


### PR DESCRIPTION
Le problème des ActiveRecord::RecordNotFound dans le SmsDeliveryJob vient du fait qu'on wrap la creation de la notif et son envoie dans une transaction.

```
appointment.transaction do
        NotificationFactory.perform(appointment)
        appointment.summon_notif.send_now if send_sms?(transition) && appointment.convict.can_receive_sms?
        appointment.reminder_notif&.program
      end
```
La transaction suspend l'insertion en DB à la réussite de toute le bloc. Mais ne suspend pas la mise en queue du job. Du coup le job peut être traité avant que la notif soit commit en DB.

Ce mécanisme pourrait se discuter. Mais j'ai choisi de privilégier un fix simple avec un wait basic sur la mise en queue du job