### PR TITLE
Fix/divestment history

### DIFF
--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -70,6 +70,7 @@ class Convict < ApplicationRecord
                                              ignoring: :accents
 
   delegate :name, to: :cpip, allow_nil: true, prefix: true
+  delegate :tj, to: :organizations, allow_nil: true
 
   def self.delete_delay
     18.month.ago

--- a/app/models/divestment.rb
+++ b/app/models/divestment.rb
@@ -26,7 +26,7 @@ class Divestment < ApplicationRecord
 
     after_transition pending: %i[accepted auto_accepted refused] do |divestment, transition|
       divestment.update(decision_date: Time.zone.now)
-      divestment.record_history_for_transition(transition.event == :refused ? :refused : :accepted)
+      divestment.record_history_for_transition(transition.event == :refuse ? :refuse : :accept)
     end
   end
 

--- a/app/models/divestment.rb
+++ b/app/models/divestment.rb
@@ -24,11 +24,13 @@ class Divestment < ApplicationRecord
       transition pending: :refused
     end
 
-    after_transition pending: any do |divestment, transition|
+    after_transition pending: %i[accepted auto_accepted refused] do |divestment, transition|
       divestment.update(decision_date: Time.zone.now)
-      divestment.record_history_for_transition(transition.event)
+      divestment.record_history_for_transition(transition.event == :refused ? :refused : :accepted)
     end
   end
+
+  delegate :name, to: :organization, prefix: true
 
   paginates_per 5
 
@@ -44,7 +46,7 @@ class Divestment < ApplicationRecord
       convict:,
       event:,
       category: 'convict',
-      data: { target_name: organization.name }
+      data: { divestment: self }
     )
   end
 

--- a/app/models/history_item.rb
+++ b/app/models/history_item.rb
@@ -28,7 +28,7 @@ class HistoryItem < ApplicationRecord
     remove_phone_convict: 17,
     failed_programmed_reminder_notification: 18,
     accept_divestment: 19,
-    refuse_organization_divestment: 20
+    refuse_divestment: 20
   }
 
   def self.validate_event(event)

--- a/app/models/organization_divestment.rb
+++ b/app/models/organization_divestment.rb
@@ -20,7 +20,7 @@ class OrganizationDivestment < ApplicationRecord
   }
 
   scope :unanswered, -> { where(state: %i[pending]) }
-  scope :answered, -> { where(state: %i[accepted auto_accepted refused]) }
+  scope :answered, -> { where(state: %i[ignored accepted auto_accepted refused]) }
 
   state_machine initial: :pending do
     event :accept do
@@ -61,6 +61,6 @@ class OrganizationDivestment < ApplicationRecord
   end
 
   def answered?
-    accepted? || auto_accepted? || refused?
+    ignored? || accepted? || auto_accepted? || refused?
   end
 end

--- a/app/models/organization_divestment.rb
+++ b/app/models/organization_divestment.rb
@@ -19,7 +19,7 @@ class OrganizationDivestment < ApplicationRecord
       .where('last_reminder_email_at IS NULL OR last_reminder_email_at <= ?', 5.days.ago)
   }
 
-  scope :unanswered, -> { where(state: %i[pending ignored]) }
+  scope :unanswered, -> { where(state: %i[pending]) }
   scope :answered, -> { where(state: %i[accepted auto_accepted refused]) }
 
   state_machine initial: :pending do
@@ -54,10 +54,6 @@ class OrganizationDivestment < ApplicationRecord
 
   def convict_name
     convict.full_name
-  end
-
-  def unanswered?
-    pending? || ignored?
   end
 
   def positively_answered?

--- a/app/models/organization_divestment.rb
+++ b/app/models/organization_divestment.rb
@@ -41,11 +41,12 @@ class OrganizationDivestment < ApplicationRecord
 
     after_transition %i[pending ignored] => any do |organization_divestment, transition|
       organization_divestment.update(decision_date: Time.zone.now)
-      organization_divestment.record_history_for_transition(transition.event)
     end
   end
 
   paginates_per 5
+
+  delegate :name, to: :organization, prefix: true
 
   def source
     divestment.organization
@@ -53,22 +54,6 @@ class OrganizationDivestment < ApplicationRecord
 
   def convict_name
     convict.full_name
-  end
-
-  def record_history_for_transition(transition_event)
-    event = "#{transition_event}_organization_divestment"
-    return unless HistoryItem.validate_event(event)
-
-    HistoryItemFactory.perform(
-      convict:,
-      event:,
-      category: 'convict',
-      data: {
-        organization_name: organization.name,
-        target_name: divestment.organization.name,
-        comment:
-      }
-    )
   end
 
   def unanswered?

--- a/app/models/organization_divestment.rb
+++ b/app/models/organization_divestment.rb
@@ -57,7 +57,7 @@ class OrganizationDivestment < ApplicationRecord
   end
 
   def positively_answered?
-    accepted? || auto_accepted?
+    ignored? || accepted? || auto_accepted?
   end
 
   def answered?

--- a/app/models/organization_divestment.rb
+++ b/app/models/organization_divestment.rb
@@ -39,7 +39,7 @@ class OrganizationDivestment < ApplicationRecord
       transition pending: :ignored
     end
 
-    after_transition %i[pending ignored] => any do |organization_divestment, transition|
+    after_transition %i[pending ignored] => any do |organization_divestment, _transition|
       organization_divestment.update(decision_date: Time.zone.now)
     end
   end

--- a/app/policies/organization_divestment_policy.rb
+++ b/app/policies/organization_divestment_policy.rb
@@ -21,6 +21,6 @@ class OrganizationDivestmentPolicy < ApplicationPolicy
     return false unless user.security_charter_accepted? && user.local_admin?
     return false unless record.convict.valid?
 
-    record.unanswered? && user.organization == record.organization
+    record.pending? && user.organization == record.organization
   end
 end

--- a/app/services/divestment_creator_service.rb
+++ b/app/services/divestment_creator_service.rb
@@ -60,9 +60,12 @@ class DivestmentCreatorService
 
   def initial_state(org, state)
     return state unless state == 'pending'
-    return 'auto_accepted' if org.spip? && @convict.organizations.intersect?(org.tjs)
+    return 'ignored' if org.local_admin.empty?
 
-    org.users.where(role: 'local_admin').empty? ? 'ignored' : state
+    if org.spip? && @convict.organizations.intersect?(org.tjs)
+      return 'auto_accepted' unless@convict.organizations.tj.map(&:local_admin).flatten.empty?
+    end
+    state
   end
 
   def initial_comment(state)

--- a/app/services/divestment_creator_service.rb
+++ b/app/services/divestment_creator_service.rb
@@ -62,9 +62,10 @@ class DivestmentCreatorService
     return state unless state == 'pending'
     return 'ignored' if org.local_admin.empty?
 
-    if org.spip? && @convict.organizations.intersect?(org.tjs)
-      return 'auto_accepted' unless@convict.organizations.tj.map(&:local_admin).flatten.empty?
+    if org.spip? && @convict.organizations.intersect?(org.tjs) && @convict.tj.map(&:local_admin).flatten.present?
+      return 'auto_accepted'
     end
+
     state
   end
 

--- a/app/services/divestment_creator_service.rb
+++ b/app/services/divestment_creator_service.rb
@@ -38,6 +38,7 @@ class DivestmentCreatorService
     )
     @divestment.decision_date = Time.zone.now if state == 'auto_accepted'
     @divestment.save!
+    @divestment.record_history_for_transition(:accept) if @divestment.auto_accepted?
   end
 
   def create_organization_divestments(divestment, state)

--- a/app/services/divestment_state_service.rb
+++ b/app/services/divestment_state_service.rb
@@ -9,7 +9,7 @@ class DivestmentStateService
 
   def accept(comment = nil)
     return false unless @convict.valid?
-    return false unless @organization_divestment.unanswered? && @divestment.pending?
+    return false unless @organization_divestment.pending? && @divestment.pending?
 
     ActiveRecord::Base.transaction do
       return false unless comment.nil? || @organization_divestment.update!(comment:)
@@ -24,7 +24,7 @@ class DivestmentStateService
   # rubocop:disable Metrics/CyclomaticComplexity
   def refuse(comment = nil)
     return false unless @convict.valid?
-    return false unless @organization_divestment.unanswered? && @divestment.pending?
+    return false unless @organization_divestment.pending? && @divestment.pending?
 
     ActiveRecord::Base.transaction do
       return false unless comment.nil? || @organization_divestment.update!(comment:)

--- a/app/services/history_item_factory.rb
+++ b/app/services/history_item_factory.rb
@@ -42,7 +42,7 @@ module HistoryItemFactory
                                                     user_name: data[:user_name], user_role: data[:user_role])
       when 'refuse_divestment'
         relevant_org_divestment = data[:divestment].organization_divestments.with_state(:refused).first
-        comment = relevant_org_divestment.comment.present? ? relevant_org_divestment : 'décision sans commentaire'
+        comment = relevant_org_divestment.comment.present? ? relevant_org_divestment.comment : 'décision sans commentaire'
         I18n.t('history_item.refuse_divestment', comment:, organization_name: relevant_org_divestment.organization_name,
                                                  target_name: data[:divestment].organization_name)
       when 'accept_divestment'

--- a/app/services/history_item_factory.rb
+++ b/app/services/history_item_factory.rb
@@ -40,13 +40,13 @@ module HistoryItemFactory
       when 'remove_phone_convict'
         I18n.t('history_item.remove_phone_convict', name: convict.name, old_phone: data[:old_phone].phony_formatted,
                                                     user_name: data[:user_name], user_role: data[:user_role])
-      when 'refuse_organization_divestment'
-        comment = data[:comment].present? ? data[:comment] : 'décision sans commentaire'
-        I18n.t('history_item.refuse_organization_divestment', comment:,
-                                                              organization_name: data[:organization_name],
-                                                              target_name: data[:target_name])
+      when 'refuse_divestment'
+        relevant_org_divestment = data[:divestment].organization_divestments.with_state(:refused).first
+        comment = relevant_org_divestment.comment.present? ? relevant_org_divestment : 'décision sans commentaire'
+        I18n.t('history_item.refuse_divestment', comment:, organization_name: relevant_org_divestment.organization_name,
+                                                 target_name: data[:divestment].organization_name)
       when 'accept_divestment'
-        I18n.t('history_item.accept_divestment', target_name: data[:target_name])
+        I18n.t('history_item.accept_divestment', target_name: data[:divestment].organization_name)
       end
     end
     # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/services/history_item_factory.rb
+++ b/app/services/history_item_factory.rb
@@ -42,8 +42,8 @@ module HistoryItemFactory
                                                     user_name: data[:user_name], user_role: data[:user_role])
       when 'refuse_divestment'
         relevant_org_divestment = data[:divestment].organization_divestments.with_state(:refused).first
-        comment = relevant_org_divestment.comment.present? ? relevant_org_divestment.comment : 'décision sans commentaire'
-        I18n.t('history_item.refuse_divestment', comment:, organization_name: relevant_org_divestment.organization_name,
+        I18n.t('history_item.refuse_divestment', comment: relevant_org_divestment.comment || 'aucun commentaire',
+                                                 organization_name: relevant_org_divestment.organization_name,
                                                  target_name: data[:divestment].organization_name)
       when 'accept_divestment'
         I18n.t('history_item.accept_divestment', target_name: data[:divestment].organization_name)

--- a/app/views/convicts/_duplicate_convict_card.html.erb
+++ b/app/views/convicts/_duplicate_convict_card.html.erb
@@ -1,0 +1,30 @@
+<div class="fr-container fr-mt-5w fr-mb-5w">
+  <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
+    <div class="fr-alert fr-alert--warning">
+      <h3 class="fr-alert__title">Attention : ce probationnaire existe déjà</h3>
+      <% dups_details&.each do |result| %>
+        <% duplicate_convict = result[:convict] %>
+        <p><%= result[:alert] %></p>
+        <p><%= result[:alert_details] %></p>
+        <% if duplicate_convict.phone.present? %>
+          <p><%= t('activerecord.attributes.convict.phone')%>: <%= duplicate_convict.display_phone %></p>
+        <% end %>
+        <% if duplicate_convict.appi_uuid.present? %>
+          <p><%= t('activerecord.attributes.convict.appi_uuid') %>: <%= duplicate_convict.appi_uuid %></p>
+        <% end %>
+        <% if result[:show_button] %>
+          <div class="fr-container fr-mt-5w fr-mb-5w">
+            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
+              <% if policy(duplicate_convict).be_divested? %>
+                <% button_message = (user.work_at_bex? && duplicate_convict.valid?) ? t('new_divestment_bex') : t('new_divestment') %>
+                <%= button_to button_message, divestments_path, method: :post, class: 'fr-btn', params: { convict_id: duplicate_convict.id }, data: { confirm: t('new_divestment_confirm'), turbo: false } %>
+              <% else %>
+                Code 12 - Dessaisissement impossible pour ce probationnaire, veuillez contacter un administrateur.
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/convicts/new.html.erb
+++ b/app/views/convicts/new.html.erb
@@ -141,35 +141,8 @@
         </div>
       </div>
     <% end %>
-    <% @dups_details&.each do |result| %>
-      <% duplicate_convict = result[:convict] %>
-      <div class="fr-container fr-mt-5w fr-mb-5w">
-        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
-          <div class="fr-alert fr-alert--warning">
-            <h3 class="fr-alert__title">Attention : ce probationnaire existe déjà</h3>
-            <p><%= result[:alert] %></p>
-            <p><%= result[:alert_details] %></p>
-            <% if duplicate_convict.phone.present? %>
-              <p><%= t('activerecord.attributes.convict.phone')%>: <%= duplicate_convict.display_phone %></p>
-            <% end %>
-            <% if duplicate_convict.appi_uuid.present? %>
-              <p><%= t('activerecord.attributes.convict.appi_uuid') %>: <%= duplicate_convict.appi_uuid %></p>
-            <% end %>
-            <% if result[:show_button] %>
-              <div class="fr-container fr-mt-5w fr-mb-5w">
-                <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
-                  <% if policy(duplicate_convict).be_divested? %>
-                    <% button_message = (current_user.work_at_bex? && duplicate_convict.valid?) ? t('new_divestment_bex') : t('new_divestment') %>
-                    <%= button_to button_message, divestments_path, method: :post, class: 'fr-btn', params: { convict_id: duplicate_convict.id }, data: { confirm: t('new_divestment_confirm'), turbo: false } %>
-                  <% else %>
-                    Code 12 - Dessaisissement impossible pour ce probationnaire, veuillez contacter un administrateur.
-                  <% end %>
-                </div>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      </div>
+    <% if @dups_details.present? %>
+      <%= render 'duplicate_convict_card', dups_details: @dups_details, user: current_user %>
     <% end %>
   </div>
 </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -531,8 +531,8 @@ fr:
     add_phone_convict: "Un numéro de téléphone pour %{name} a été ajouté par %{user_name} (%{user_role}). Nouveau numéro : %{new_phone}."
     remove_phone_convict_title: "Numéro supprimé"
     remove_phone_convict: "Le numéro de téléphone de %{name} a été supprimé par %{user_name} (%{user_role}). Ancien numéro : %{old_phone}."
-    refuse_organization_divestment_title: "Refus de dessaisissement"
-    refuse_organization_divestment: "Le dessaisissement vers %{target_name} a été refusé par %{organization_name} (%{comment})."
+    refuse_divestment_title: "Refus de dessaisissement"
+    refuse_divestment: "Le dessaisissement vers %{target_name} a été refusé par %{organization_name} (%{comment})."
     accept_divestment_title: "Dessaisissement accepté"
     accept_divestment: "Le dessaisissement vers %{target_name} est maintenant effectif."
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -803,7 +803,7 @@ fr:
       request_date: 'Date de demande'
       requesting_service: 'Service demandeur'
       decision: 'Votre décision'
-      comment: 'Commentaire'
+      comment: 'Votre commentaire'
       action: 'Actions'
       status: Status
       services: Services

--- a/spec/models/history_item_spec.rb
+++ b/spec/models/history_item_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe HistoryItem, type: :model do
         remove_phone_convict: 17,
         failed_programmed_reminder_notification: 18,
         accept_divestment: 19,
-        refuse_organization_divestment: 20
+        refuse_divestment: 20
       }
     )
   }


### PR DESCRIPTION
Petite explication d'un choix: la gestion du statut ignored.

Avant le statut ignored était donné dans 3 cas:
- Un service n'a pas d'admin locaux (il ne peut pas donner son mot)
- Un service a refusé donc les autre ne peuvent plus (ils ne peuvent plus donner leur mot)
- Un service n'a pas répondu sous 10 jours

Dans ce 3ème cas, le service peut encore répondre. Du coup, le statut ignored perdait un peu de cohérence. Ca m'a facilité la vie sur certains fix de ne plus passer le divestment à ignored quand un service n'y a pas répondu sous 10 jours. Du coup, désormais, ignorer vaut réponse et acceptation tacite (dans les 2 cas restants le service qui ignore n'a plus son mot à dire)