### PR TITLE
Fix future app divestment

### DIFF
--- a/app/models/convict.rb
+++ b/app/models/convict.rb
@@ -18,6 +18,7 @@ class Convict < ApplicationRecord
   has_many :organizations, through: :convicts_organizations_mappings
 
   has_many :appointments, dependent: :destroy
+  has_many :slots, through: :appointments
   has_many :history_items, dependent: :destroy
 
   has_many :divestments, dependent: :destroy
@@ -270,6 +271,17 @@ class Convict < ApplicationRecord
 
   def last_appointment_in_the_past?
     last_appointment_at_least_x_months_old?(0)
+  end
+
+  # Check if the convict has no future appointments outside an organization or its linked organizations
+  def no_future_appointments_outside_organization_and_links?(organization)
+    linked_organization_ids = [organization.id] + organization.linked_organizations.pluck(:id)
+
+    slots
+      .joins(agenda: :place)
+      .where('slots.date > ?', Date.today)
+      .where.not(places: { organization_id: linked_organization_ids })
+      .empty?
   end
 
   def pending_divestments?

--- a/app/services/divestment_stalled_service.rb
+++ b/app/services/divestment_stalled_service.rb
@@ -10,7 +10,7 @@ class DivestmentStalledService
     OrganizationDivestment.old_pending.each do |organization_divestment|
       convict = organization_divestment.convict
       service = DivestmentStateService.new(organization_divestment, nil)
-      if divestmentable?(convict)
+      if divestmentable?(convict, organization_divestment)
         service.accept("Accepté automatiquement après 10 jours d'attente", auto_accepted: true)
       end
     end
@@ -31,7 +31,8 @@ class DivestmentStalledService
     end
   end
 
-  def divestmentable?(convict)
-    convict.archived? || convict.last_appointment_in_the_past?
+  def divestmentable?(convict, organization_divestment)
+    organization = organization_divestment.divestment.organization
+    convict.archived? || convict.no_future_appointments_outside_organization_and_links?(organization)
   end
 end

--- a/spec/models/convict_spec.rb
+++ b/spec/models/convict_spec.rb
@@ -623,35 +623,37 @@ RSpec.describe Convict, type: :model do
   describe '#no_future_appointments_outside_organization_and_links?' do
     let(:organization) { create(:organization, organization_type: 'spip') }
     let(:linked_organization) { create(:organization, organization_type: 'tj') }
-    let(:other_organization) { create(:organization) }
     let(:place) { create(:place, organization: organization) }
     let(:linked_place) { create(:place, organization: linked_organization) }
-    let(:other_place) { create(:place, organization: other_organization) }
     let(:agenda_in_org) { create(:agenda, place: place) }
     let(:agenda_in_linked_org) { create(:agenda, place: linked_place) }
-    let(:agenda_outside_orgs) { create(:agenda, place: other_place) }
     let(:slot_in_org) { create(:slot, date: Date.tomorrow, agenda: agenda_in_org) }
     let(:slot_in_linked_org) { create(:slot, date: Date.tomorrow, agenda: agenda_in_linked_org) }
-    let(:slot_outside_orgs) { create(:slot, date: Date.tomorrow, agenda: agenda_outside_orgs) }
     let(:convict) { create(:convict) }
 
     before do
-      # Define linked organizations
       allow(organization).to receive(:linked_organizations).and_return([linked_organization])
 
-      # Create appointments
       create(:appointment, convict: convict, slot: slot_in_org)
       create(:appointment, convict: convict, slot: slot_in_linked_org)
-      create(:appointment, convict: convict, slot: slot_outside_orgs)
+    end
+    context 'the convict has future appointments outside the organization and its links' do
+      let(:other_organization) { create(:organization) }
+      let(:slot_outside_orgs) { create(:slot, date: Date.tomorrow, agenda: agenda_outside_orgs) }
+      let(:other_place) { create(:place, organization: other_organization) }
+      let(:agenda_outside_orgs) { create(:agenda, place: other_place) }
+      let!(:appointment_outside) do
+        create(:appointment, convict: convict, slot: slot_outside_orgs)
+      end
+      it 'returns false if ' do
+        expect(convict.no_future_appointments_outside_organization_and_links?(organization)).to eq(false)
+      end
     end
 
-    it 'returns false if the convict has future appointments outside the organization and its links' do
-      expect(convict.no_future_appointments_outside_organization_and_links?(organization)).to eq(false)
-    end
-
-    it 'returns true if the convict has no future appointments outside the organization and its links' do
-      convict.appointments.where(slot: slot_outside_orgs).destroy_all # Remove outside appointments
-      expect(convict.no_future_appointments_outside_organization_and_links?(organization)).to eq(true)
+    context 'the convict has no future appointments outside the organization and its links' do
+      it 'returns true' do
+        expect(convict.no_future_appointments_outside_organization_and_links?(organization)).to eq(true)
+      end
     end
   end
 end

--- a/spec/models/convict_spec.rb
+++ b/spec/models/convict_spec.rb
@@ -619,4 +619,39 @@ RSpec.describe Convict, type: :model do
       end
     end
   end
+
+  describe '#no_future_appointments_outside_organization_and_links?' do
+    let(:organization) { create(:organization, organization_type: 'spip') }
+    let(:linked_organization) { create(:organization, organization_type: 'tj') }
+    let(:other_organization) { create(:organization) }
+    let(:place) { create(:place, organization: organization) }
+    let(:linked_place) { create(:place, organization: linked_organization) }
+    let(:other_place) { create(:place, organization: other_organization) }
+    let(:agenda_in_org) { create(:agenda, place: place) }
+    let(:agenda_in_linked_org) { create(:agenda, place: linked_place) }
+    let(:agenda_outside_orgs) { create(:agenda, place: other_place) }
+    let(:slot_in_org) { create(:slot, date: Date.tomorrow, agenda: agenda_in_org) }
+    let(:slot_in_linked_org) { create(:slot, date: Date.tomorrow, agenda: agenda_in_linked_org) }
+    let(:slot_outside_orgs) { create(:slot, date: Date.tomorrow, agenda: agenda_outside_orgs) }
+    let(:convict) { create(:convict) }
+
+    before do
+      # Define linked organizations
+      allow(organization).to receive(:linked_organizations).and_return([linked_organization])
+
+      # Create appointments
+      create(:appointment, convict: convict, slot: slot_in_org)
+      create(:appointment, convict: convict, slot: slot_in_linked_org)
+      create(:appointment, convict: convict, slot: slot_outside_orgs)
+    end
+
+    it 'returns false if the convict has future appointments outside the organization and its links' do
+      expect(convict.no_future_appointments_outside_organization_and_links?(organization)).to eq(false)
+    end
+
+    it 'returns true if the convict has no future appointments outside the organization and its links' do
+      convict.appointments.where(slot: slot_outside_orgs).destroy_all # Remove outside appointments
+      expect(convict.no_future_appointments_outside_organization_and_links?(organization)).to eq(true)
+    end
+  end
 end

--- a/spec/services/divestment_stalled_service_spec.rb
+++ b/spec/services/divestment_stalled_service_spec.rb
@@ -2,8 +2,11 @@ require 'rails_helper'
 
 RSpec.describe DivestmentStalledService do
   describe '#call' do
-    let(:convict) { instance_double('Convict', archived?: false, last_appointment_in_the_past?: false) }
-    let(:divestment) { instance_double('Divestment', convict:) }
+    let(:organization) { instance_double('Organization') }
+    let(:convict) do
+      instance_double('Convict', archived?: false, no_future_appointments_outside_organization_and_links?: false)
+    end
+    let(:divestment) { instance_double('Divestment', convict:, organization:) }
     let(:organization_divestment) { instance_double('OrganizationDivestment', divestment:) }
     let(:organization_divestment2) { instance_double('OrganizationDivestment', divestment:) }
     let(:state_service) { instance_double('DivestmentStateService', accept: nil) }
@@ -25,7 +28,7 @@ RSpec.describe DivestmentStalledService do
         DivestmentStalledService.new.call
       end
       it 'calls accept on DivestmentStateService' do
-        allow(convict).to receive_messages(last_appointment_in_the_past?: true)
+        allow(convict).to receive_messages(no_future_appointments_outside_organization_and_links?: true)
         expect(state_service).to receive(:accept)
         DivestmentStalledService.new.call
       end
@@ -38,7 +41,7 @@ RSpec.describe DivestmentStalledService do
         DivestmentStalledService.new.call
       end
       it 'does not call accept on DivestmentStateService' do
-        allow(convict).to receive_messages(last_appointment_in_the_past?: false)
+        allow(convict).to receive_messages(no_future_appointments_outside_organization_and_links?: false)
         expect(state_service).not_to receive(:accept)
         DivestmentStalledService.new.call
       end


### PR DESCRIPTION
l'auto acceptation des divestments est bloqué quand un agent bex prend un rdv apres creation du dessaisissement a cause de last_appointment_in_the_past?.
Dans cette PR, on verifie a la place si le probationnaire a des convocations dans le futur uniquement dans le service cible du dessaisissement ou ses organizations liée